### PR TITLE
Fix publish locking

### DIFF
--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -24,3 +24,4 @@ def publish_version(dandiset_id: int, user_id) -> None:
         # The draft was locked in django by the publish action
         # We need to unlock it now
         dandiset.draft_version.unlock(User.objects.get(id=user_id))
+        dandiset.draft_version.save()

--- a/dandiapi/api/views/draft_version.py
+++ b/dandiapi/api/views/draft_version.py
@@ -86,6 +86,7 @@ def draft_publish_view(request, dandiset__pk):
     # Locking will fail if the draft is currently locked
     # We want the draft to stay locked until publish completes or fails
     dandiset.draft_version.lock(request.user)
+    dandiset.draft_version.save()
     publish_version.delay(dandiset.id, request.user.id)
     return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
The publish endpoint was not saving the lock/unlock actions, so drafts
weren't actually being locked while publish was in progress.