### PR TITLE
Remove Version.create_or_find helper

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 
 from django.contrib.postgres.fields import JSONField
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import RegexValidator
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
@@ -24,13 +23,6 @@ class VersionMetadata(TimeStampedModel):
 
     def __str__(self) -> str:
         return self.name
-
-    @classmethod
-    def create_or_find(cls, metadata, name):
-        try:
-            return cls.objects.get(metadata=metadata, name=name)
-        except ObjectDoesNotExist:
-            return cls(metadata=metadata, name=name)
 
 
 def _get_default_version() -> str:

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -48,8 +48,14 @@ class DandisetViewSet(ReadOnlyModelViewSet):
     def create(self, request):
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        version_metadata = VersionMetadata.create_or_find(**serializer.validated_data)
-        version_metadata.save()
+
+        version_metadata, created = VersionMetadata.objects.get_or_create(
+            name=serializer.validated_data['name'],
+            metadata=serializer.validated_data['metadata'],
+        )
+        if created:
+            version_metadata.save()
+
         dandiset = Dandiset()
         dandiset.save()
         assign_perm('owner', request.user, dandiset)

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -42,8 +42,12 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        version_metadata = VersionMetadata.create_or_find(**serializer.validated_data)
-        version_metadata.save()
+        version_metadata, created = VersionMetadata.objects.get_or_create(
+            name=serializer.validated_data['name'],
+            metadata=serializer.validated_data['metadata'],
+        )
+        if created:
+            version_metadata.save()
 
         version.metadata = version_metadata
         version.save()


### PR DESCRIPTION
The Version.create_or_find() helper performs the same work as
Version.objects.get_or_create(). Remove it in favor of the native
solution.