### PR TITLE
Swagger returns

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -44,7 +44,10 @@ class DandisetViewSet(ReadOnlyModelViewSet):
 
         return super().get_object()
 
-    @swagger_auto_schema(request_body=VersionMetadataSerializer())
+    @swagger_auto_schema(
+        request_body=VersionMetadataSerializer(),
+        responses={200: DandisetSerializer()},
+    )
     def create(self, request):
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -65,6 +68,12 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         serializer = DandisetSerializer(instance=dandiset)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(method='GET', responses={200: UserSerializer(many=True)})
+    @swagger_auto_schema(
+        method='PUT',
+        request_body=UserSerializer(many=True),
+        responses={200: UserSerializer(many=True)},
+    )
     # TODO move these into a viewset
     @action(methods=['GET', 'PUT'], detail=True)
     def users(self, request, dandiset__pk):

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -144,7 +144,9 @@ def upload_complete_view(request: Request) -> HttpResponseBase:
 
 
 @swagger_auto_schema(
-    method='POST', request_body=UploadValidationRequestSerializer(), responses={204: 'No content'}
+    method='POST',
+    request_body=UploadValidationRequestSerializer(),
+    responses={204: 'No content'},
 )
 @api_view(['POST'])
 @parser_classes([JSONParser])

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -28,7 +28,10 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     lookup_field = 'version'
     lookup_value_regex = Version.VERSION_REGEX
 
-    @swagger_auto_schema(request_body=VersionMetadataSerializer())
+    @swagger_auto_schema(
+        request_body=VersionMetadataSerializer(),
+        responses={200: VersionDetailSerializer()},
+    )
     # @permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk'))
     def update(self, request, **kwargs):
         """Update the metadata of a version."""
@@ -55,7 +58,8 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
         serializer = VersionDetailSerializer(instance=version)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @action(detail=True, methods=['POST'], serializer_class=None)
+    @swagger_auto_schema(request_body=None, responses={200: VersionSerializer()})
+    @action(detail=True, methods=['POST'])
     # @permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk'))
     def publish(self, request, **kwargs):
         old_version = self.get_object()


### PR DESCRIPTION
We have many viewsets with custom actions. Swagger cannot dynamically determine the response shape of these actions, so it must be specified manually using `@swagger_auto_schema`.