### PR TITLE
Token auth endpoints

### DIFF
--- a/dandiapi/api/tests/test_auth.py
+++ b/dandiapi/api/tests/test_auth.py
@@ -1,0 +1,37 @@
+import pytest
+from rest_framework.authtoken.models import Token
+
+
+@pytest.fixture
+def token(user) -> Token:
+    token = Token(user=user)
+    token.save()
+    return token
+
+
+@pytest.mark.django_db
+def test_auth_token_retrieve(api_client, user, token):
+    api_client.force_authenticate(user=user)
+
+    assert api_client.get('/api/auth/token/').data == token.key
+
+
+@pytest.mark.django_db
+def test_auth_token_retrieve_unauthorized(api_client, user, token):
+    assert api_client.get('/api/auth/token/').status_code == 401
+
+
+@pytest.mark.django_db
+def test_auth_token_refresh(api_client, user, token):
+    api_client.force_authenticate(user=user)
+
+    new_token_key = api_client.post('/api/auth/token/').data
+    assert new_token_key != token.key
+
+    new_token = Token.objects.get(user=user)
+    assert new_token_key == new_token.key
+
+
+@pytest.mark.django_db
+def test_auth_token_reset_unauthorized(api_client, user, token):
+    assert api_client.post('/api/auth/token/').status_code == 401

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -42,7 +42,7 @@ def test_upload_initialize_unauthorized(api_client):
             {},
             format='json',
         ).status_code
-        == 403
+        == 401
     )
 
 
@@ -75,7 +75,7 @@ def test_upload_complete_unauthorized(api_client):
             {},
             format='json',
         ).status_code
-        == 403
+        == 401
     )
 
 

--- a/dandiapi/api/views/__init__.py
+++ b/dandiapi/api/views/__init__.py
@@ -1,4 +1,5 @@
 from .asset import AssetViewSet
+from .auth import auth_token_view
 from .dandiset import DandisetViewSet
 from .search import search_view
 from .stats import stats_view
@@ -14,6 +15,7 @@ __all__ = [
     'AssetViewSet',
     'DandisetViewSet',
     'VersionViewSet',
+    'auth_token_view',
     'upload_initialize_view',
     'upload_complete_view',
     'upload_validate_view',

--- a/dandiapi/api/views/auth.py
+++ b/dandiapi/api/views/auth.py
@@ -15,7 +15,6 @@ from rest_framework.response import Response
     responses={200: 'The user token'},
 )
 @api_view(['GET', 'POST'])
-# @parser_classes([JSONParser])
 @permission_classes([IsAuthenticated])
 def auth_token_view(request: Request) -> HttpResponseBase:
     if request.method == 'GET':

--- a/dandiapi/api/views/auth.py
+++ b/dandiapi/api/views/auth.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from django.http.response import HttpResponseBase
+from django.shortcuts import get_object_or_404
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.authtoken.models import Token
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+
+@swagger_auto_schema(
+    methods=['GET', 'POST'],
+    responses={200: 'The user token'},
+)
+@api_view(['GET', 'POST'])
+# @parser_classes([JSONParser])
+@permission_classes([IsAuthenticated])
+def auth_token_view(request: Request) -> HttpResponseBase:
+    if request.method == 'GET':
+        token = get_object_or_404(Token, user=request.user)
+    elif request.method == 'POST':
+        Token.objects.filter(user=request.user).delete()
+        token = Token.objects.create(user=request.user)
+    return Response(token.key)

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -7,13 +7,7 @@ from django.http.response import HttpResponseBase
 from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers, status
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.decorators import (
-    api_view,
-    authentication_classes,
-    parser_classes,
-    permission_classes,
-)
+from rest_framework.decorators import api_view, parser_classes, permission_classes
 from rest_framework.exceptions import ValidationError
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
@@ -85,7 +79,6 @@ class UploadValidationRequestSerializer(serializers.Serializer):
 )
 @api_view(['POST'])
 @parser_classes([JSONParser])
-@authentication_classes([SessionAuthentication])
 @permission_classes([IsAuthenticated])
 def upload_initialize_view(request: Request) -> HttpResponseBase:
     """
@@ -120,7 +113,6 @@ def upload_initialize_view(request: Request) -> HttpResponseBase:
 )
 @api_view(['POST'])
 @parser_classes([JSONParser])
-@authentication_classes([SessionAuthentication])
 @permission_classes([IsAuthenticated])
 def upload_complete_view(request: Request) -> HttpResponseBase:
     """
@@ -154,7 +146,6 @@ def upload_complete_view(request: Request) -> HttpResponseBase:
 )
 @api_view(['POST'])
 @parser_classes([JSONParser])
-@authentication_classes([SessionAuthentication])
 @permission_classes([IsAuthenticated])
 def upload_validate_view(request: Request) -> HttpResponseBase:
     """
@@ -199,7 +190,6 @@ def upload_validate_view(request: Request) -> HttpResponseBase:
 @swagger_auto_schema(method='GET', responses={200: ValidationErrorSerializer()})
 @api_view(['GET'])
 @parser_classes([JSONParser])
-@authentication_classes([SessionAuthentication])
 @permission_classes([IsAuthenticated])
 def upload_get_validation_view(request: Request, sha256: str) -> HttpResponseBase:
     """Get the status of a validation."""

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -10,6 +10,7 @@ from dandiapi.api.views import (
     AssetViewSet,
     DandisetViewSet,
     VersionViewSet,
+    auth_token_view,
     search_view,
     stats_view,
     upload_complete_view,
@@ -64,6 +65,7 @@ class DandisetIDConverter:
 register_converter(DandisetIDConverter, 'dandiset_id')
 urlpatterns = [
     path('api/', include(router.urls)),
+    path('api/auth/token/', auth_token_view, name='auth-token'),
     path('api/search/', search_view),
     path('api/stats/', stats_view),
     path('api/uploads/initialize/', upload_initialize_view, name='upload-initialize'),


### PR DESCRIPTION
These endpoints will allow users to retrieve and refresh an access token once they are already logged in. Users will be able to log in to the swagger page, then use these endpoints to get the access token, which they can then use to authenticate requests from cURLs or the CLI by including an `Authorization: Token {token}` header.

This does not solve the problem of logging in through the web GUI, but it does provide functionality that will be required for CLI usage.