### PR TITLE
Sort versions by created date

### DIFF
--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -17,7 +17,7 @@ from dandiapi.api.views.serializers import (
 
 
 class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewSet):
-    queryset = Version.objects.all().select_related('dandiset')
+    queryset = Version.objects.all().select_related('dandiset').order_by('created')
     queryset_detail = queryset
 
     permission_classes = [IsAuthenticatedOrReadOnly]


### PR DESCRIPTION
This ensures that versions are well ordered by publish date, so the UI
can reliably determine what the most recent version was.