### PR TITLE
Add search users endpoint

### DIFF
--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -1,0 +1,90 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_user_search(api_client, user_factory):
+
+    user = user_factory()
+    # Create more users to filter out
+    user_factory()
+    user_factory()
+    user_factory()
+
+    assert (
+        api_client.get(
+            '/api/users/search/?',
+            {'username': user.username},
+            format='json',
+        ).data
+        == [{'username': user.username}]
+    )
+
+
+@pytest.mark.django_db
+def test_user_search_blank_username(api_client, user):
+
+    assert (
+        api_client.get(
+            '/api/users/search/?',
+            {'username': ''},
+            format='json',
+        ).data
+        == {'username': ['This field may not be blank.']}
+    )
+
+
+@pytest.mark.django_db
+def test_user_search_no_matches(api_client, user):
+
+    assert (
+        api_client.get(
+            '/api/users/search/?',
+            {'username': '_'},
+            format='json',
+        ).data
+        == []
+    )
+
+
+@pytest.mark.django_db
+def test_user_search_multiple_matches(api_client, user_factory):
+
+    usernames = [
+        'jane_doe',
+        'jane_foo',
+        'jane_bar',
+        'john_doe',
+        'john_foo',
+        'john_bar',
+    ]
+    for username in usernames:
+        user_factory(username=username)
+
+    expected_usernames = usernames[:3]
+    expected_usernames.sort()
+
+    assert (
+        api_client.get(
+            '/api/users/search/?',
+            {'username': 'jane'},
+            format='json',
+        ).data
+        == [{'username': username} for username in expected_usernames]
+    )
+
+
+@pytest.mark.django_db
+def test_user_search_limit_enforced(api_client, user_factory):
+
+    usernames = [f'jane_{i:02}' for i in range(0, 100)]
+    for username in usernames:
+        user_factory(username=username)
+
+    assert (
+        api_client.get(
+            '/api/users/search/?',
+            {'username': 'jane'},
+            format='json',
+        ).data
+        == [{'username': username} for username in usernames[:10]]
+    )

--- a/dandiapi/api/views/__init__.py
+++ b/dandiapi/api/views/__init__.py
@@ -9,6 +9,7 @@ from .upload import (
     upload_initialize_view,
     upload_validate_view,
 )
+from .users import users_search_view
 from .version import VersionViewSet
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     'upload_complete_view',
     'upload_validate_view',
     'upload_get_validation_view',
+    'users_search_view',
     'search_view',
     'stats_view',
 ]

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -17,6 +17,12 @@ class UserSerializer(serializers.Serializer):
     username = serializers.CharField(validators=[UnicodeUsernameValidator()])
 
 
+class UserDetailSerializer(serializers.Serializer):
+    username = serializers.CharField(validators=[UnicodeUsernameValidator()])
+    first_name = serializers.CharField(validators=[UnicodeUsernameValidator()])
+    last_name = serializers.CharField(validators=[UnicodeUsernameValidator()])
+
+
 class DandisetSerializer(serializers.ModelSerializer):
     class Meta:
         model = Dandiset

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -3,21 +3,23 @@ from __future__ import annotations
 from django.contrib.auth.models import User
 from django.http.response import HttpResponseBase
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework.decorators import api_view, parser_classes
+from rest_framework.decorators import api_view, parser_classes, permission_classes
 from rest_framework.parsers import JSONParser
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from dandiapi.api.views.serializers import UserSerializer
+from dandiapi.api.views.serializers import UserDetailSerializer, UserSerializer
 
 
 @swagger_auto_schema(
     method='GET',
     query_serializer=UserSerializer,
-    responses={200: UserSerializer(many=True)},
+    responses={200: UserDetailSerializer(many=True)},
 )
 @api_view(['GET'])
 @parser_classes([JSONParser])
+@permission_classes([IsAuthenticated])
 def users_search_view(request: Request) -> HttpResponseBase:
     """Search for a user."""
     request_serializer = UserSerializer(data=request.query_params)
@@ -26,5 +28,5 @@ def users_search_view(request: Request) -> HttpResponseBase:
 
     options = User.objects.filter(username__startswith=username).order_by('username')[:10]
 
-    response_serializer = UserSerializer(options, many=True)
+    response_serializer = UserDetailSerializer(options, many=True)
     return Response(response_serializer.data)

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from django.contrib.auth.models import User
+from django.http.response import HttpResponseBase
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.decorators import api_view, parser_classes
+from rest_framework.parsers import JSONParser
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from dandiapi.api.views.serializers import UserSerializer
+
+
+@swagger_auto_schema(
+    method='GET',
+    query_serializer=UserSerializer,
+    responses={200: UserSerializer(many=True)},
+)
+@api_view(['GET'])
+@parser_classes([JSONParser])
+def users_search_view(request: Request) -> HttpResponseBase:
+    """Search for a user."""
+    request_serializer = UserSerializer(data=request.query_params)
+    request_serializer.is_valid(raise_exception=True)
+    username: str = request_serializer.validated_data['username']
+
+    options = User.objects.filter(username__startswith=username).order_by('username')[:10]
+
+    response_serializer = UserSerializer(options, many=True)
+    return Response(response_serializer.data)

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -17,6 +17,7 @@ from dandiapi.api.views import (
     upload_get_validation_view,
     upload_initialize_view,
     upload_validate_view,
+    users_search_view,
 )
 
 router = ExtendedSimpleRouter()
@@ -76,6 +77,7 @@ urlpatterns = [
         upload_get_validation_view,
         name='upload-get-validation',
     ),
+    path('api/users/search/', users_search_view),
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),


### PR DESCRIPTION
Add an endpoint to search for users. This is used when selecting owners to add in the DandisetOwnersDialog.