### PR TITLE
Register rest_framework TokenAuthentication

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -59,7 +59,8 @@ class DandiConfig(ConfigMixin):
         configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += [
             # Required for swagger logins
             'rest_framework.authentication.SessionAuthentication',
-            # TODO remove TokenAuthentication, it is only here to support the setTokenHack login workaround
+            # TODO remove TokenAuthentication, it is only here to support
+            # the setTokenHack login workaround
             'rest_framework.authentication.TokenAuthentication',
         ]
 

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -57,7 +57,10 @@ class DandiConfig(ConfigMixin):
         ]
         configuration.AUTHENTICATION_BACKENDS += ['guardian.backends.ObjectPermissionBackend']
         configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += [
-            'rest_framework.authentication.SessionAuthentication'
+            # Required for swagger logins
+            'rest_framework.authentication.SessionAuthentication',
+            # TODO remove TokenAuthentication, it is only here to support the setTokenHack login workaround
+            'rest_framework.authentication.TokenAuthentication',
         ]
 
     DANDI_DANDISETS_BUCKET_NAME = values.Value(environ_required=True)


### PR DESCRIPTION
An update to django-composed-configuration removed the
`rest_framework.authentication.TokenAuthentication` auth class from the
configuration, which broke the `setTokenHack` and other token auth
stuff. This workaround needs to be removed later, as it should be
replaced with the new django-oauth-toolkit auth class.