### PR TITLE
Make GitHub the only login method in production

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -89,4 +89,5 @@ class ProductionConfiguration(DandiConfig, SentryConfig, ProductionBaseConfigura
 
 
 class HerokuProductionConfiguration(DandiConfig, SentryConfig, HerokuProductionBaseConfiguration):
-    pass
+    # All login attempts in production should go straight to GitHub
+    LOGIN_URL = '/accounts/github/login/'


### PR DESCRIPTION
Clicking `Login` in production will now take you straight to the GitHub login page. In development and test it will take you to the default `accounts/login/` page, as these environments don't have GitHub logins set up.