### PR TITLE
Most recent version

### DIFF
--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -10,18 +10,18 @@ def build_message(subject, message, to, html_message):
 
 
 def removed_subject(dandiset):
-    return f'Removed from Dandiset {dandiset.identifier}'
+    return f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
 
 
 def removed_message(dandiset):
-    return f'You have been removed as an owner of Dandiset {dandiset.identifier}.'
+    return f'You have been removed as an owner of Dandiset "{dandiset.most_recent_version.name}".'
 
 
 def removed_html_message(dandiset):
     return (
         'You have been removed as an owner of Dandiset '
         f'<a href="https://dandiarchive.org/dandiset/{dandiset.identifier}">'
-        f'{dandiset.identifier}'
+        f'{dandiset.most_recent_version.name}'
         '</a>.'
     )
 
@@ -36,18 +36,18 @@ def build_removed_message(dandiset, removed_owner):
 
 
 def added_subject(dandiset):
-    return f'Added to Dandiset {dandiset.identifier}'
+    return f'Added to Dandiset "{dandiset.most_recent_version.name}"'
 
 
 def added_message(dandiset):
-    return f'You have been made an owner of Dandiset {dandiset.identifier}.'
+    return f'You have been made an owner of Dandiset "{dandiset.most_recent_version.name}".'
 
 
 def added_html_message(dandiset):
     return (
-        'You have been made an owner of Dandiset'
+        'You have been made an owner of Dandiset '
         f'<a href="https://dandiarchive.org/dandiset/{dandiset.identifier}">'
-        f'{dandiset.identifier}'
+        f'{dandiset.most_recent_version.name}'
         '</a>.'
     )
 

--- a/dandiapi/api/models/dandiset.py
+++ b/dandiapi/api/models/dandiset.py
@@ -20,6 +20,10 @@ class Dandiset(TimeStampedModel):
         return f'{self.id:06}' if self.id is not None else ''
 
     @property
+    def most_recent_version(self):
+        return self.versions.order_by('created').last()
+
+    @property
     def owners(self):
         return get_users_with_perms(self, only_with_perms_in=['owner'])
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -124,10 +124,9 @@ def test_dandiset_rest_create(api_client, user):
     assert list(dandiset.owners.all()) == [user]
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
-    version = dandiset.versions.get()
-    assert version.version == 'draft'
-    assert version.metadata.name == name
-    assert version.metadata.metadata == metadata
+    assert dandiset.most_recent_version.version == 'draft'
+    assert dandiset.most_recent_version.metadata.name == name
+    assert dandiset.most_recent_version.metadata.metadata == metadata
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -1,4 +1,3 @@
-from django.core import mail
 from guardian.shortcuts import assign_perm
 import pytest
 
@@ -161,7 +160,7 @@ def test_dandiset_rest_get_owners(api_client, dandiset, user):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_change_owner(api_client, version, user_factory):
+def test_dandiset_rest_change_owner(api_client, version, user_factory, mailoutbox):
     dandiset = version.dandiset
     user1 = user_factory()
     user2 = user_factory()
@@ -178,15 +177,15 @@ def test_dandiset_rest_change_owner(api_client, version, user_factory):
     assert resp.data == [{'username': user2.username}]
     assert list(dandiset.owners) == [user2]
 
-    assert len(mail.outbox) == 2
-    assert mail.outbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
-    assert mail.outbox[0].to == [user1.email]
-    assert mail.outbox[1].subject == f'Added to Dandiset "{dandiset.most_recent_version.name}"'
-    assert mail.outbox[1].to == [user2.email]
+    assert len(mailoutbox) == 2
+    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
+    assert mailoutbox[0].to == [user1.email]
+    assert mailoutbox[1].subject == f'Added to Dandiset "{dandiset.most_recent_version.name}"'
+    assert mailoutbox[1].to == [user2.email]
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_add_owner(api_client, version, user_factory):
+def test_dandiset_rest_add_owner(api_client, version, user_factory, mailoutbox):
     dandiset = version.dandiset
     user1 = user_factory()
     user2 = user_factory()
@@ -203,13 +202,13 @@ def test_dandiset_rest_add_owner(api_client, version, user_factory):
     assert resp.data == [{'username': user1.username}, {'username': user2.username}]
     assert list(dandiset.owners) == [user1, user2]
 
-    assert len(mail.outbox) == 1
-    assert mail.outbox[0].subject == f'Added to Dandiset "{dandiset.most_recent_version.name}"'
-    assert mail.outbox[0].to == [user2.email]
+    assert len(mailoutbox) == 1
+    assert mailoutbox[0].subject == f'Added to Dandiset "{dandiset.most_recent_version.name}"'
+    assert mailoutbox[0].to == [user2.email]
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_remove_owner(api_client, version, user_factory):
+def test_dandiset_rest_remove_owner(api_client, version, user_factory, mailoutbox):
     dandiset = version.dandiset
     user1 = user_factory()
     user2 = user_factory()
@@ -227,9 +226,9 @@ def test_dandiset_rest_remove_owner(api_client, version, user_factory):
     assert resp.data == [{'username': user1.username}]
     assert list(dandiset.owners) == [user1]
 
-    assert len(mail.outbox) == 1
-    assert mail.outbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
-    assert mail.outbox[0].to == [user2.email]
+    assert len(mailoutbox) == 1
+    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
+    assert mailoutbox[0].to == [user2.email]
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -161,7 +161,8 @@ def test_dandiset_rest_get_owners(api_client, dandiset, user):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_change_owner(api_client, dandiset, user_factory):
+def test_dandiset_rest_change_owner(api_client, version, user_factory):
+    dandiset = version.dandiset
     user1 = user_factory()
     user2 = user_factory()
     assign_perm('owner', user1, dandiset)
@@ -178,14 +179,15 @@ def test_dandiset_rest_change_owner(api_client, dandiset, user_factory):
     assert list(dandiset.owners) == [user2]
 
     assert len(mail.outbox) == 2
-    assert mail.outbox[0].subject == f'Removed from Dandiset {dandiset.identifier}'
+    assert mail.outbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
     assert mail.outbox[0].to == [user1.email]
-    assert mail.outbox[1].subject == f'Added to Dandiset {dandiset.identifier}'
+    assert mail.outbox[1].subject == f'Added to Dandiset "{dandiset.most_recent_version.name}"'
     assert mail.outbox[1].to == [user2.email]
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_add_owner(api_client, dandiset, user_factory):
+def test_dandiset_rest_add_owner(api_client, version, user_factory):
+    dandiset = version.dandiset
     user1 = user_factory()
     user2 = user_factory()
     assign_perm('owner', user1, dandiset)
@@ -202,12 +204,13 @@ def test_dandiset_rest_add_owner(api_client, dandiset, user_factory):
     assert list(dandiset.owners) == [user1, user2]
 
     assert len(mail.outbox) == 1
-    assert mail.outbox[0].subject == f'Added to Dandiset {dandiset.identifier}'
+    assert mail.outbox[0].subject == f'Added to Dandiset "{dandiset.most_recent_version.name}"'
     assert mail.outbox[0].to == [user2.email]
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_remove_owner(api_client, dandiset, user_factory):
+def test_dandiset_rest_remove_owner(api_client, version, user_factory):
+    dandiset = version.dandiset
     user1 = user_factory()
     user2 = user_factory()
     assign_perm('owner', user1, dandiset)
@@ -225,7 +228,7 @@ def test_dandiset_rest_remove_owner(api_client, dandiset, user_factory):
     assert list(dandiset.owners) == [user1]
 
     assert len(mail.outbox) == 1
-    assert mail.outbox[0].subject == f'Removed from Dandiset {dandiset.identifier}'
+    assert mail.outbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
     assert mail.outbox[0].to == [user2.email]
 
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -39,7 +39,12 @@ def test_dandiset_rest_list(api_client, dandiset):
         'next': None,
         'previous': None,
         'results': [
-            {'identifier': dandiset.identifier, 'created': TIMESTAMP_RE, 'modified': TIMESTAMP_RE}
+            {
+                'identifier': dandiset.identifier,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+                'most_recent_version': None,
+            }
         ],
     }
 
@@ -56,7 +61,12 @@ def test_dandiset_rest_list_for_user(api_client, user, dandiset_factory):
         'next': None,
         'previous': None,
         'results': [
-            {'identifier': dandiset.identifier, 'created': TIMESTAMP_RE, 'modified': TIMESTAMP_RE}
+            {
+                'identifier': dandiset.identifier,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+                'most_recent_version': None,
+            }
         ],
     }
 
@@ -67,7 +77,20 @@ def test_dandiset_rest_retrieve(api_client, dandiset):
         'identifier': dandiset.identifier,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
+        'most_recent_version': None,
     }
+
+
+"""
+
+                'most_recent_version': {
+                    'version': dandiset.most_recent_version.version,
+                    'name': dandiset.most_recent_version.name,
+                    'asset_count': dandiset.most_recent_version.asset_count,
+                    'size': dandiset.most_recent_version.size,
+                    'metadata': dandiset.most_recent_version.metadata,
+                },
+"""
 
 
 @pytest.mark.django_db
@@ -83,6 +106,15 @@ def test_dandiset_rest_create(api_client, user):
         'identifier': DANDISET_ID_RE,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
+        'most_recent_version': {
+            'version': 'draft',
+            'name': name,
+            'asset_count': 0,
+            'size': 0,
+            'metadata': metadata,
+            'created': TIMESTAMP_RE,
+            'modified': TIMESTAMP_RE,
+        },
     }
     id = int(response.data['identifier'])
 

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -16,7 +16,7 @@ from dandiapi.api.mail import send_ownership_change_emails
 from dandiapi.api.models import Dandiset, Version, VersionMetadata
 from dandiapi.api.views.common import DandiPagination
 from dandiapi.api.views.serializers import (
-    DandisetSerializer,
+    DandisetDetailSerializer,
     UserSerializer,
     VersionMetadataSerializer,
 )
@@ -49,7 +49,7 @@ class DandisetFilterBackend(filters.OrderingFilter):
 
 class DandisetViewSet(ReadOnlyModelViewSet):
     permission_classes = [IsAuthenticatedOrReadOnly]
-    serializer_class = DandisetSerializer
+    serializer_class = DandisetDetailSerializer
     pagination_class = DandiPagination
     filter_backends = [DandisetFilterBackend]
 
@@ -81,7 +81,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
 
     @swagger_auto_schema(
         request_body=VersionMetadataSerializer(),
-        responses={200: DandisetSerializer()},
+        responses={200: DandisetDetailSerializer()},
     )
     def create(self, request):
         serializer = VersionMetadataSerializer(data=request.data)
@@ -100,7 +100,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         version = Version(dandiset=dandiset, metadata=version_metadata, version='draft')
         version.save()
 
-        serializer = DandisetSerializer(instance=dandiset)
+        serializer = DandisetDetailSerializer(instance=dandiset)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     # @permission_required_or_403('owner', (Dandiset, 'dandiset__pk'))

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -24,6 +24,25 @@ class UserDetailSerializer(serializers.Serializer):
     admin = serializers.BooleanField()
 
 
+class MostRecentVersionSerializer(serializers.ModelSerializer):
+    """A Version serializer that does not include dandiset to prevent infinite loops."""
+
+    class Meta:
+        model = Version
+        fields = [
+            'version',
+            'name',
+            'asset_count',
+            'size',
+            'metadata',
+            'created',
+            'modified',
+        ]
+        read_only_fields = ['created', 'metadata']
+
+    metadata = serializers.SlugRelatedField(read_only=True, slug_field='metadata')
+
+
 class DandisetSerializer(serializers.ModelSerializer):
     class Meta:
         model = Dandiset
@@ -33,6 +52,13 @@ class DandisetSerializer(serializers.ModelSerializer):
             'modified',
         ]
         read_only_fields = ['created']
+
+
+class DandisetDetailSerializer(DandisetSerializer):
+    class Meta(DandisetSerializer.Meta):
+        fields = DandisetSerializer.Meta.fields + ['most_recent_version']
+
+    most_recent_version = MostRecentVersionSerializer(read_only=True)
 
 
 class VersionMetadataSerializer(serializers.ModelSerializer):

--- a/scripts/map_ids.py
+++ b/scripts/map_ids.py
@@ -13,7 +13,7 @@ from dandiapi.api.models.dandiset import Dandiset
 
 
 def get_new_identifier(dandiset):
-    metadata = dandiset.versions.order_by('created').last().metadata.metadata
+    metadata = dandiset.most_recent_version.metadata.metadata
     if 'identifier' not in metadata:
         print(f'Dandiset {dandiset.identifier} does not specify an identifier')
         return None


### PR DESCRIPTION
* Add a new computed property on `Dandiset` models, `most_recent_version`, that finds the most recent version for that dandiset.
* Include `most_recent_version` on the serializer for all views in `DandisetViewSet`. This drastically lowers the number of queries required on the Dandiset Listing page. Previously 17 were required (1 to list dandisets, 8 to fetch all the versions IDs for each dandiset, then 8 more to get the details of the most recent version for each dandiset). Now listing dandisets includes details for the most recent version, so only 1 query is required.
* Use `most_recent_version` when sending ownership change emails to render the name of the dandiset in the email, instead of using the identifier.
* Update a few places where we were calculating the `most_recent_version` with a queryset.