### PR TITLE
Tweak dandiset serializer

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -110,7 +110,11 @@ def test_dandiset_rest_create(api_client, user):
             'name': name,
             'asset_count': 0,
             'size': 0,
-            'metadata': metadata,
+            'dandiset': {
+                'identifier': DANDISET_ID_RE,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+            },
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
         },

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -24,25 +24,6 @@ class UserDetailSerializer(serializers.Serializer):
     admin = serializers.BooleanField()
 
 
-class MostRecentVersionSerializer(serializers.ModelSerializer):
-    """A Version serializer that does not include dandiset to prevent infinite loops."""
-
-    class Meta:
-        model = Version
-        fields = [
-            'version',
-            'name',
-            'asset_count',
-            'size',
-            'metadata',
-            'created',
-            'modified',
-        ]
-        read_only_fields = ['created', 'metadata']
-
-    metadata = serializers.SlugRelatedField(read_only=True, slug_field='metadata')
-
-
 class DandisetSerializer(serializers.ModelSerializer):
     class Meta:
         model = Dandiset
@@ -52,13 +33,6 @@ class DandisetSerializer(serializers.ModelSerializer):
             'modified',
         ]
         read_only_fields = ['created']
-
-
-class DandisetDetailSerializer(DandisetSerializer):
-    class Meta(DandisetSerializer.Meta):
-        fields = DandisetSerializer.Meta.fields + ['most_recent_version']
-
-    most_recent_version = MostRecentVersionSerializer(read_only=True)
 
 
 class VersionMetadataSerializer(serializers.ModelSerializer):
@@ -87,6 +61,13 @@ class VersionSerializer(serializers.ModelSerializer):
 
     dandiset = DandisetSerializer()
     # name = serializers.SlugRelatedField(read_only=True, slug_field='name')
+
+
+class DandisetDetailSerializer(DandisetSerializer):
+    class Meta(DandisetSerializer.Meta):
+        fields = DandisetSerializer.Meta.fields + ['most_recent_version']
+
+    most_recent_version = VersionSerializer(read_only=True)
 
 
 class VersionDetailSerializer(VersionSerializer):


### PR DESCRIPTION
Previously, a `MostRecentVersionSerializer` was defined to avoid
including extra information when serializing dandisets. This was more
complicated on the backend and required more special handling on the
frontend, so instead of that, Dandiset views now use a serializer that
looks like this:

```
{
  "identifier": ...
  "most_recent_version": {
    "version": ...
    ...
    "dandiset": {
      "identifier": ...
    {
  {
}
```

The dandiset identifier is now included twice, but now
`most_recent_version` uses the normal `VersionSerializer` so it doesn't
require any special handling in the client.