### PR TITLE
Map ids endpoint

### DIFF
--- a/dandiapi/api/dandiset_migration.py
+++ b/dandiapi/api/dandiset_migration.py
@@ -1,0 +1,69 @@
+"""
+Maps the identifiers of all Dandisets to the identifier listed in their metadata.
+
+Identifier cycles are not addressed.
+If you have Dandiset 000001 with {"identifier":000002} and Dandiset 000002
+with {"identifier":000001}, manual intervention is required.
+"""
+from dandiapi.api.models.dandiset import Dandiset
+
+
+def get_new_identifier(dandiset):
+    metadata = dandiset.most_recent_version.metadata.metadata
+    if 'identifier' not in metadata:
+        print(f'Dandiset {dandiset.identifier} does not specify an identifier')
+        return None
+    try:
+        identifier = int(metadata['identifier'])
+    except ValueError:
+        print(
+            f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
+        )
+        return None
+
+    if 0 > identifier or identifier > 999999:
+        print(
+            f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
+        )
+        return None
+
+    if dandiset.id == identifier:
+        # The identifier already matches
+        return None
+
+    if Dandiset.objects.filter(id=identifier):
+        print(
+            f'Dandiset {dandiset.identifier} cannot be copied because {identifier} already exists'
+        )
+        return None
+
+    return identifier
+
+
+def move(dandiset, new_id):
+    # Grab the old dandiset's relevant information
+    owners = dandiset.owners
+    versions = list(dandiset.versions.all())
+
+    # Create a new dandiset with the new identifier
+    new_dandiset = Dandiset(id=new_id)
+    new_dandiset.save()
+
+    # Copy the owners
+    new_dandiset.set_owners(owners)
+    new_dandiset.save()
+
+    # Copy the versions
+    for version in versions:
+        version.dandiset = new_dandiset
+        version.save()
+
+    # Delete the old dandiset
+    dandiset.delete()
+
+
+def move_if_necessary(dandiset):
+    new_id = get_new_identifier(dandiset)
+    if new_id:
+        print(f'Copying dandiset {dandiset.identifier} to {new_id}')
+        move(dandiset, new_id)

--- a/dandiapi/api/dandiset_migration.py
+++ b/dandiapi/api/dandiset_migration.py
@@ -8,21 +8,25 @@ with {"identifier":000001}, manual intervention is required.
 from dandiapi.api.models.dandiset import Dandiset
 
 
+# Track log messages instead of logs.appending so they can be output in rest response
+logs = []
+
+
 def get_new_identifier(dandiset):
     metadata = dandiset.most_recent_version.metadata.metadata
     if 'identifier' not in metadata:
-        print(f'Dandiset {dandiset.identifier} does not specify an identifier')
+        logs.append(f'Dandiset {dandiset.identifier} does not specify an identifier')
         return None
     try:
         identifier = int(metadata['identifier'])
     except ValueError:
-        print(
+        logs.append(
             f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
         )
         return None
 
     if 0 > identifier or identifier > 999999:
-        print(
+        logs.append(
             f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
         )
         return None
@@ -32,7 +36,7 @@ def get_new_identifier(dandiset):
         return None
 
     if Dandiset.objects.filter(id=identifier):
-        print(
+        logs.append(
             f'Dandiset {dandiset.identifier} cannot be copied because {identifier} already exists'
         )
         return None
@@ -63,7 +67,10 @@ def move(dandiset, new_id):
 
 
 def move_if_necessary(dandiset):
+    global logs
+    logs = []
     new_id = get_new_identifier(dandiset)
     if new_id:
-        print(f'Copying dandiset {dandiset.identifier} to {new_id}')
+        logs.append(f'Copying dandiset {dandiset.identifier} to {new_id}')
         move(dandiset, new_id)
+    return logs

--- a/dandiapi/api/dandiset_migration.py
+++ b/dandiapi/api/dandiset_migration.py
@@ -7,7 +7,6 @@ with {"identifier":000001}, manual intervention is required.
 """
 from dandiapi.api.models.dandiset import Dandiset
 
-
 # Track log messages instead of logs.appending so they can be output in rest response
 logs = []
 

--- a/dandiapi/api/dandiset_migration.py
+++ b/dandiapi/api/dandiset_migration.py
@@ -32,7 +32,7 @@ def get_new_identifier(dandiset):
         return None
 
     if dandiset.id == identifier:
-        # The identifier already matches
+        logs.append(f'Dandiset {dandiset.identifier} already has the correct identifier')
         return None
 
     if Dandiset.objects.filter(id=identifier):

--- a/dandiapi/api/views/temporary_hack.py
+++ b/dandiapi/api/views/temporary_hack.py
@@ -18,14 +18,15 @@ from dandiapi.api.models import Dandiset
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def map_ids_view(request: Request) -> HttpResponseBase:
+    logs = []
     for dandiset in Dandiset.objects.all():
-        move_if_necessary(dandiset)
-    return Response()
+        logs += move_if_necessary(dandiset)
+    return Response(logs)
 
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def map_id_view(request: Request, dandiset_id) -> HttpResponseBase:
     dandiset = get_object_or_404(Dandiset, pk=dandiset_id)
-    move_if_necessary(dandiset)
-    return Response()
+    logs = move_if_necessary(dandiset)
+    return Response(logs)

--- a/dandiapi/api/views/temporary_hack.py
+++ b/dandiapi/api/views/temporary_hack.py
@@ -1,11 +1,5 @@
-from django.conf import settings
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.http.response import HttpResponseBase
 from django.shortcuts import get_object_or_404
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
-from rest_framework.authtoken.models import Token
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request

--- a/dandiapi/api/views/temporary_hack.py
+++ b/dandiapi/api/views/temporary_hack.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.http.response import HttpResponseBase
+from django.shortcuts import get_object_or_404
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.authtoken.models import Token
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from dandiapi.api.dandiset_migration import move_if_necessary
+from dandiapi.api.models import Dandiset
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def map_ids_view(request: Request) -> HttpResponseBase:
+    for dandiset in Dandiset.objects.all():
+        move_if_necessary(dandiset)
+    return Response()
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def map_id_view(request: Request, dandiset_id) -> HttpResponseBase:
+    dandiset = get_object_or_404(Dandiset, pk=dandiset_id)
+    move_if_necessary(dandiset)
+    return Response()

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -81,11 +81,9 @@ urlpatterns = [
     ),
     path('api/users/me/', users_me_view),
     path('api/users/search/', users_search_view),
-    
     # TODO remove these endpoints after migration
     path('api/scripts/map_ids/', map_ids_view, name='map-ids'),
     re_path(r'^api/scripts/map_ids/(?P<dandiset_id>[0-9]{6})/$', map_id_view, name='map-id'),
-    
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -20,6 +20,7 @@ from dandiapi.api.views import (
     users_me_view,
     users_search_view,
 )
+from dandiapi.api.views.temporary_hack import map_ids_view, map_id_view
 
 router = ExtendedSimpleRouter()
 (
@@ -80,6 +81,9 @@ urlpatterns = [
     ),
     path('api/users/me/', users_me_view),
     path('api/users/search/', users_search_view),
+    # TODO remove these endpoints after migration
+    path('api/scripts/map_ids/', map_ids_view, name='map-ids'),
+    re_path(r'^api/scripts/map_ids/(?P<dandiset_id>[0-9]{6})/$', map_id_view, name='map-id'),
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -81,9 +81,11 @@ urlpatterns = [
     ),
     path('api/users/me/', users_me_view),
     path('api/users/search/', users_search_view),
+    
     # TODO remove these endpoints after migration
     path('api/scripts/map_ids/', map_ids_view, name='map-ids'),
     re_path(r'^api/scripts/map_ids/(?P<dandiset_id>[0-9]{6})/$', map_id_view, name='map-id'),
+    
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -20,7 +20,7 @@ from dandiapi.api.views import (
     users_me_view,
     users_search_view,
 )
-from dandiapi.api.views.temporary_hack import map_ids_view, map_id_view
+from dandiapi.api.views.temporary_hack import map_id_view, map_ids_view
 
 router = ExtendedSimpleRouter()
 (

--- a/scripts/map_ids.py
+++ b/scripts/map_ids.py
@@ -9,8 +9,8 @@ If you have Dandiset 000001 with {"identifier":000002} and Dandiset 000002
 with {"identifier":000001}, manual intervention is required.
 """
 
-from dandiapi.api.models.dandiset import Dandiset
 from dandiapi.api.dandiset_migration import move_if_necessary
+from dandiapi.api.models.dandiset import Dandiset
 
 
 def run():

--- a/scripts/map_ids.py
+++ b/scripts/map_ids.py
@@ -15,4 +15,6 @@ from dandiapi.api.dandiset_migration import move_if_necessary
 
 def run():
     for dandiset in Dandiset.objects.all():
-        move_if_necessary(dandiset)
+        logs = move_if_necessary(dandiset)
+        for line in logs:
+            print(line)

--- a/scripts/map_ids.py
+++ b/scripts/map_ids.py
@@ -10,65 +10,9 @@ with {"identifier":000001}, manual intervention is required.
 """
 
 from dandiapi.api.models.dandiset import Dandiset
-
-
-def get_new_identifier(dandiset):
-    metadata = dandiset.most_recent_version.metadata.metadata
-    if 'identifier' not in metadata:
-        print(f'Dandiset {dandiset.identifier} does not specify an identifier')
-        return None
-    try:
-        identifier = int(metadata['identifier'])
-    except ValueError:
-        print(
-            f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
-        )
-        return None
-
-    if 0 > identifier or identifier > 999999:
-        print(
-            f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
-        )
-        return None
-
-    if dandiset.id == identifier:
-        # The identifier already matches
-        return None
-
-    if Dandiset.objects.filter(id=identifier):
-        print(
-            f'Dandiset {dandiset.identifier} cannot be copied because {identifier} already exists'
-        )
-        return None
-
-    return identifier
-
-
-def move(dandiset, new_id):
-    # Grab the old dandiset's relevant information
-    owners = dandiset.owners
-    versions = list(dandiset.versions.all())
-
-    # Create a new dandiset with the new identifier
-    new_dandiset = Dandiset(id=new_id)
-    new_dandiset.save()
-
-    # Copy the owners
-    new_dandiset.set_owners(owners)
-    new_dandiset.save()
-
-    # Copy the versions
-    for version in versions:
-        version.dandiset = new_dandiset
-        version.save()
-
-    # Delete the old dandiset
-    dandiset.delete()
+from dandiapi.api.dandiset_migration import move_if_necessary
 
 
 def run():
     for dandiset in Dandiset.objects.all():
-        new_id = get_new_identifier(dandiset)
-        if new_id:
-            print(f'Copying dandiset {dandiset.identifier} to {new_id}')
-            move(dandiset, new_id)
+        move_if_necessary(dandiset)


### PR DESCRIPTION
* Copy the `map_ids.py` script into the `api` package so it can be referenced by the new views
* Add views to run `map_ids` against a specific dandiset or a single dandiset
* Do some really ugly stuff to log `map_ids` progress into a list of strings rather than stdout, then return it from the views.