### PR TITLE
Use request_body=no_body on VersionViewSet.publish

### DIFF
--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -1,4 +1,4 @@
-from drf_yasg.utils import swagger_auto_schema, no_body
+from drf_yasg.utils import no_body, swagger_auto_schema
 from guardian.utils import get_40x_or_None
 from rest_framework import status
 from rest_framework.decorators import action

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -1,4 +1,4 @@
-from drf_yasg.utils import swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema, no_body
 from guardian.utils import get_40x_or_None
 from rest_framework import status
 from rest_framework.decorators import action
@@ -58,7 +58,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
         serializer = VersionDetailSerializer(instance=version)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @swagger_auto_schema(request_body=None, responses={200: VersionSerializer()})
+    @swagger_auto_schema(request_body=no_body, responses={200: VersionSerializer()})
     @action(detail=True, methods=['POST'])
     # @permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk'))
     def publish(self, request, **kwargs):


### PR DESCRIPTION
`drf-yasg` generates the endpoints on the Swagger page automatically, but sometimes makes incorrect guesses. In this case, it assumes that all POST endpoints require request bodies, which is not the case for the `publish` endpoint.

The solution is to use the `@swagger_auto_schema` decorator to indicate that the `request_body` is `no_body`. I originally tried to this by using `None`, but `no_body` is required to explicitly disable the request body.

Resolves #72 