### PR TITLE
Throw meaningful duplicate asset error

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -184,7 +184,7 @@ def test_asset_create_duplicate(api_client, user, asset):
         format='json',
     )
     assert resp.status_code == 400
-    assert resp.data == 'asset already exists'
+    assert resp.data == 'Asset Already Exists'
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -169,6 +169,25 @@ def test_asset_create_not_an_owner(api_client, user, version):
 
 
 @pytest.mark.django_db
+def test_asset_create_duplicate(api_client, user, asset):
+    version = asset.version
+    assign_perm('owner', user, version.dandiset)
+    api_client.force_authenticate(user=user)
+
+    resp = api_client.post(
+        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/assets/',
+        {
+            'path': asset.path,
+            'metadata': asset.metadata.metadata,
+            'sha256': asset.sha256,
+        },
+        format='json',
+    )
+    assert resp.status_code == 400
+    assert resp.data == 'asset already exists'
+
+
+@pytest.mark.django_db
 def test_asset_rest_update(api_client, user, asset, asset_blob):
     assign_perm('owner', user, asset.version.dandiset)
     api_client.force_authenticate(user=user)

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -1,4 +1,5 @@
 from django.core.validators import RegexValidator
+from django.db.utils import IntegrityError
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
@@ -85,7 +86,10 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
             metadata=asset_metadata,
             version=version,
         )
-        asset.save()
+        try:
+            asset.save()
+        except IntegrityError:
+            return Response('asset already exists', status=status.HTTP_400_BAD_REQUEST)
 
         serializer = AssetDetailSerializer(instance=asset)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -93,7 +93,7 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
             # https://www.postgresql.org/docs/13/errcodes-appendix.html
             # Postgres error code 23505 == unique_violation
             if e.__cause__.pgcode == '23505':
-                return Response('asset already exists', status=status.HTTP_400_BAD_REQUEST)
+                return Response('Asset Already Exists', status=status.HTTP_400_BAD_REQUEST)
             raise e
 
         serializer = AssetDetailSerializer(instance=asset)


### PR DESCRIPTION
Assets have a `unique_together` constraint on parent version + path, for good reason. It's possible to request a new Asset with the same parent version + path as an existing Asset, which resulted in a 500 error because of the DB throwing an `IntegrityError`.

Catch that `IntegrityError` and throw an HTTP 400.

Fixes #68 