### PR TITLE
Delete asset endpoint

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -241,6 +241,31 @@ def test_asset_rest_update_not_an_owner(api_client, user, asset):
     )
 
 
+@pytest.mark.django_db
+def test_asset_rest_delete(api_client, user, asset):
+    api_client.force_authenticate(user=user)
+    assign_perm('owner', user, asset.version.dandiset)
+
+    response = api_client.delete(
+        f'/api/dandisets/{asset.version.dandiset.identifier}/versions/{asset.version.version}/assets/{asset.uuid}/'
+    )
+    assert response.status_code == 204
+
+    assert not Asset.objects.all()
+
+
+@pytest.mark.django_db
+def test_asset_rest_delete_not_an_owner(api_client, user, asset):
+    api_client.force_authenticate(user=user)
+
+    response = api_client.delete(
+        f'/api/dandisets/{asset.version.dandiset.identifier}/versions/{asset.version.version}/assets/{asset.uuid}/'
+    )
+    assert response.status_code == 403
+
+    assert asset in Asset.objects.all()
+
+
 # @pytest.mark.django_db
 # @pytest.mark.parametrize(
 #     'new_path,expected',

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -247,7 +247,8 @@ def test_asset_rest_delete(api_client, user, asset):
     assign_perm('owner', user, asset.version.dandiset)
 
     response = api_client.delete(
-        f'/api/dandisets/{asset.version.dandiset.identifier}/versions/{asset.version.version}/assets/{asset.uuid}/'
+        f'/api/dandisets/{asset.version.dandiset.identifier}/'
+        f'versions/{asset.version.version}/assets/{asset.uuid}/'
     )
     assert response.status_code == 204
 
@@ -259,7 +260,8 @@ def test_asset_rest_delete_not_an_owner(api_client, user, asset):
     api_client.force_authenticate(user=user)
 
     response = api_client.delete(
-        f'/api/dandisets/{asset.version.dandiset.identifier}/versions/{asset.version.version}/assets/{asset.uuid}/'
+        f'/api/dandisets/{asset.version.dandiset.identifier}/'
+        f'versions/{asset.version.version}/assets/{asset.uuid}/'
     )
     assert response.status_code == 403
 

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -124,6 +124,19 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         serializer = AssetDetailSerializer(instance=asset)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    # @permission_required_or_403('owner', (Dandiset, 'pk', 'version__dandiset__pk'))
+    def destroy(self, request, **kwargs):
+        asset = self.get_object()
+
+        # TODO @permission_required doesn't work on methods
+        # https://github.com/django-guardian/django-guardian/issues/723
+        response = get_40x_or_None(request, ['owner'], asset.version.dandiset, return_403=True)
+        if response:
+            return response
+
+        asset.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
     @swagger_auto_schema(
         responses={
             200: None,  # This disables the auto-generated 200 response


### PR DESCRIPTION
Fixes #70

[ViewSets](https://www.django-rest-framework.org/api-guide/viewsets/#viewset-actions) handle most of the boilerplate around generate API endpoints. All we have to do to add the DELETE endpoint for assets is to define the appropriate `destroy` method on the existing `AssetViewSet`.