### PR TITLE
Automatically populate name and identifier in VersionMetadata on Version save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dmypy.json
 .pyre/
 
 # End of https://www.gitignore.io/api/django
+
+# Editor settings
+.vscode 

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -86,8 +86,8 @@ class Version(TimeStampedModel):
             metadata={
                 **self.metadata.metadata,
                 'name': self.metadata.name,
-                'identifier': f"DANDI:{self.dandiset.identifier}"
-            }
+                'identifier': f'DANDI:{self.dandiset.identifier}',
+            },
         )
 
         if created:

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -79,5 +79,25 @@ class Version(TimeStampedModel):
     def copy(cls, version):
         return Version(dandiset=version.dandiset, metadata=version.metadata)
 
+    def _populate_metadata(self):
+        new: VersionMetadata
+        new, created = VersionMetadata.objects.get_or_create(
+            name=self.metadata.name,
+            metadata={
+                **self.metadata.metadata,
+                'name': self.metadata.name,
+                'identifier': f"DANDI:{self.dandiset.identifier}"
+            }
+        )
+
+        if created:
+            new.save()
+
+        self.metadata = new
+
+    def save(self, *args, **kwargs):
+        self._populate_metadata()
+        super().save(*args, **kwargs)
+
     def __str__(self) -> str:
         return f'{self.dandiset.identifier}/{self.version}'

--- a/dandiapi/api/tests/fuzzy.py
+++ b/dandiapi/api/tests/fuzzy.py
@@ -20,6 +20,7 @@ class Re:
 
 TIMESTAMP_RE = Re(r'\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z')
 DANDISET_ID_RE = Re(r'\d{6}')
+DANDISET_SCHEMA_ID_RE = Re(r'DANDI:\d{6}')
 VERSION_ID_RE = Re(r'0\.\d{6}\.\d{4}')
 HTTP_URL_RE = Re(r'http[s]?\://[^/]+(/[^/]+)*[/]?(&.+)?')
 UUID_RE = Re(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -3,7 +3,7 @@ import pytest
 
 from dandiapi.api.models import Dandiset
 
-from .fuzzy import DANDISET_ID_RE, TIMESTAMP_RE
+from .fuzzy import DANDISET_ID_RE, DANDISET_SCHEMA_ID_RE, TIMESTAMP_RE
 
 
 @pytest.mark.django_db
@@ -129,7 +129,11 @@ def test_dandiset_rest_create(api_client, user):
     assert dandiset.versions.count() == 1
     assert dandiset.most_recent_version.version == 'draft'
     assert dandiset.most_recent_version.metadata.name == name
-    assert dandiset.most_recent_version.metadata.metadata == metadata
+    assert dandiset.most_recent_version.metadata.metadata == {
+        **metadata,
+        'name': name,
+        'identifier': DANDISET_SCHEMA_ID_RE,
+    }
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -125,10 +125,13 @@ def test_dandiset_rest_create(api_client, user):
     # Verify that the user is the only owner.
     dandiset = Dandiset.objects.get(id=id)
     assert list(dandiset.owners.all()) == [user]
+
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
     assert dandiset.most_recent_version.version == 'draft'
     assert dandiset.most_recent_version.metadata.name == name
+
+    # Verify that name and identifier were injected
     assert dandiset.most_recent_version.metadata.metadata == {
         **metadata,
         'name': name,

--- a/dandiapi/api/tests/test_search.py
+++ b/dandiapi/api/tests/test_search.py
@@ -13,7 +13,16 @@ def test_search_empty_query(api_client):
 
 @pytest.mark.django_db
 def test_search_identifier(api_client, version):
-    resp = api_client.get('/api/search/', {'search': version.id}).data
+    resp = api_client.get('/api/search/', {'search': version.dandiset.identifier}).data
     assert len(resp) == 1
     assert resp[0]['version'] == version.version
     assert resp[0]['name'] == version.name
+
+
+@pytest.mark.django_db
+def test_search_metadata(api_client, version):
+    key = next(iter(version.metadata.metadata))
+    resp = api_client.get('/api/search/', {'search': key}).data
+
+    assert len(resp)
+    assert any([ver['dandiset']['identifier'] == version.dandiset.identifier for ver in resp])

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -97,8 +97,13 @@ def test_version_rest_update(api_client, user, version):
     assign_perm('owner', user, version.dandiset)
     api_client.force_authenticate(user=user)
 
-    new_metadata = {'foo': 'bar', 'num': 123, 'list': ['a', 'b', 'c']}
     new_name = 'A unique and special name!'
+    new_metadata = {'foo': 'bar', 'num': 123, 'list': ['a', 'b', 'c']}
+    saved_metadata = {
+        **new_metadata,
+        'name': new_name,
+        'identifier': f'DANDI:{version.dandiset.identifier}',
+    }
 
     assert api_client.put(
         f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/',
@@ -115,12 +120,12 @@ def test_version_rest_update(api_client, user, version):
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
         'asset_count': version.asset_count,
-        'metadata': new_metadata,
+        'metadata': saved_metadata,
         'size': version.size,
     }
 
     version.refresh_from_db()
-    assert version.metadata.metadata == new_metadata
+    assert version.metadata.metadata == saved_metadata
     assert version.metadata.name == new_name
 
 

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -97,6 +97,8 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         dandiset = Dandiset()
         dandiset.save()
         assign_perm('owner', request.user, dandiset)
+
+        # Create new draft version
         version = Version(dandiset=dandiset, metadata=version_metadata, version='draft')
         version.save()
 

--- a/dandiapi/api/views/search.py
+++ b/dandiapi/api/views/search.py
@@ -1,4 +1,3 @@
-from django.contrib.postgres.search import SearchVector
 from django.db.models import TextField
 from django.db.models.functions import Cast
 from drf_yasg import openapi
@@ -25,7 +24,9 @@ from dandiapi.api.views.version import VersionSerializer
 def search_view(request):
     if 'search' not in request.query_params:
         return Response([])
-    versions = Version.objects.annotate(search=SearchVector(Cast('metadata', TextField()))).filter(
-        search__contains=request.query_params['search']
-    )
+
+    versions = Version.objects.annotate(
+        text_metadata=Cast('metadata__metadata', TextField())
+    ).filter(text_metadata__search=request.query_params['search'])
+
     return Response(VersionSerializer(versions, many=True).data)

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -35,7 +35,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     # @permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk'))
     def update(self, request, **kwargs):
         """Update the metadata of a version."""
-        version = self.get_object()
+        version: Version = self.get_object()
 
         # TODO @permission_required doesn't work on methods
         # https://github.com/django-guardian/django-guardian/issues/723
@@ -45,10 +45,13 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+
+        version_metadata: VersionMetadata
         version_metadata, created = VersionMetadata.objects.get_or_create(
             name=serializer.validated_data['name'],
-            metadata=serializer.validated_data['metadata'],
+            metadata=serializer.validated_data['metadata']
         )
+
         if created:
             version_metadata.save()
 

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -48,8 +48,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
         version_metadata: VersionMetadata
         version_metadata, created = VersionMetadata.objects.get_or_create(
-            name=serializer.validated_data['name'],
-            metadata=serializer.validated_data['metadata']
+            name=serializer.validated_data['name'], metadata=serializer.validated_data['metadata']
         )
 
         if created:


### PR DESCRIPTION
Fixes #63

The main change here is an overriding of the `Version.save` method, to include automatically populating the `VersionMetadata.metadata` field with `name` and `identifier`. The format of `identifier` is dependent on [this](https://github.com/dandi/dandi-cli/pull/348) schema change.