### PR TITLE
Handle more complex identifier formats

### DIFF
--- a/dandiapi/api/dandiset_migration.py
+++ b/dandiapi/api/dandiset_migration.py
@@ -27,9 +27,9 @@ def get_new_identifier(dandiset):
         # Maybe the identifier is of format {'identifier': {'value':'...', 'propertyId': 'DANDI'}}
         try:
             identifier = int(metadata['identifier']['value'])
-        except:
+        except Exception:
             logs.append(
-                f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
+                f'Dandiset {dandiset.identifier} has a bad identifier {metadata["identifier"]}'
             )
             return None
 

--- a/dandiapi/api/dandiset_migration.py
+++ b/dandiapi/api/dandiset_migration.py
@@ -20,9 +20,18 @@ def get_new_identifier(dandiset):
         identifier = int(metadata['identifier'])
     except ValueError:
         logs.append(
-            f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
+            f'Dandiset {dandiset.identifier} has a non-integer identifier {metadata["identifier"]}'
         )
         return None
+    except TypeError:
+        # Maybe the identifier is of format {'identifier': {'value':'...', 'propertyId': 'DANDI'}}
+        try:
+            identifier = int(metadata['identifier']['value'])
+        except:
+            logs.append(
+                f'Dandiset {dandiset.identifier} has a bad metadata identifier {metadata["identifier"]}'
+            )
+            return None
 
     if 0 > identifier or identifier > 999999:
         logs.append(


### PR DESCRIPTION
There are some existing dandisets uploaded that have metadata like this:
```
{
  "identifier": {
    "propertyID": "DANDI",
    "value": "000001",
  },
  ...
}
```

This handles that behavior.