### PR TITLE
Fix object keys

### DIFF
--- a/dandiapi/api/models/validation.py
+++ b/dandiapi/api/models/validation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 from django.conf import settings
 from django.core.files.storage import Storage
 from django.core.validators import RegexValidator
@@ -14,8 +16,7 @@ def _get_validation_blob_storage() -> Storage:
 
 
 def _get_validation_blob_prefix(instance: Validation, filename: str) -> str:
-    # return f'{instance.version.dandiset.identifier}/{instance.version.version}/{filename}'
-    return filename
+    return f'{filename}/{uuid4()}'
 
 
 class Validation(TimeStampedModel):

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -22,7 +22,7 @@ def test_upload_initialize(api_client, user):
         {'file_name': file_name, 'file_size': file_size},
         format='json',
     ).data == {
-        'object_key': file_name,
+        'object_key': Re(f'{file_name}/[a-z0-9\\-]+'),
         'upload_id': UUID_RE,
         'parts': [
             {

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -96,7 +96,9 @@ def upload_initialize_view(request: Request) -> HttpResponseBase:
     # TODO The first argument to generate_filename() is an instance of the model.
     # We do not and will never have an instance of the model during field upload.
     # Maybe we need a different generate method/upload_to with a different signature?
-    object_key = Validation.blob.field.storage.generate_filename(upload_request['file_name'])
+    object_key = Validation.blob.field.storage.generate_filename(
+        Validation.blob.field.upload_to(None, upload_request['file_name'])
+    )
 
     initialization = MultipartManager.from_storage(Validation.blob.field.storage).initialize_upload(
         object_key, upload_request['file_size']


### PR DESCRIPTION
Fixes #81 

The upload process will now append a UUID to the `object_key`, so all uploads that go through the validation process are guaranteed to not overwrite eachother.

We do not use the `sha256` value because at upload time, it is given by the client. If we allow the client to give all the information that generates the object key, malicious clients could potentially give the `sha256` of a different file, overwriting the blob.