### PR TITLE
Create dandiset with identifier

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -140,6 +140,71 @@ def test_dandiset_rest_create(api_client, user):
 
 
 @pytest.mark.django_db
+def test_dandiset_rest_create_with_identifier(api_client, user):
+    api_client.force_authenticate(user=user)
+    name = 'Test Dandiset'
+    identifier = '123456'
+    metadata = {'foo': 'bar', 'identifier': f'DANDI:{identifier}'}
+
+    response = api_client.post(
+        '/api/dandisets/',
+        {'name': name, 'metadata': metadata},
+        format='json',
+    )
+    assert response.data == {
+        'identifier': identifier,
+        'created': TIMESTAMP_RE,
+        'modified': TIMESTAMP_RE,
+        'most_recent_version': {
+            'version': 'draft',
+            'name': name,
+            'asset_count': 0,
+            'size': 0,
+            'dandiset': {
+                'identifier': identifier,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+            },
+            'created': TIMESTAMP_RE,
+            'modified': TIMESTAMP_RE,
+        },
+    }
+
+    # Creating a Dandiset has side affects.
+    # Verify that the user is the only owner.
+    dandiset = Dandiset.objects.get(id=identifier)
+    assert list(dandiset.owners.all()) == [user]
+
+    # Verify that a draft Version and VersionMetadata were also created.
+    assert dandiset.versions.count() == 1
+    assert dandiset.most_recent_version.version == 'draft'
+    assert dandiset.most_recent_version.metadata.name == name
+
+    # Verify that name and identifier were injected
+    assert dandiset.most_recent_version.metadata.metadata == {
+        **metadata,
+        'name': name,
+        'identifier': f'DANDI:{identifier}',
+    }
+
+
+@pytest.mark.django_db
+def test_dandiset_rest_create_with_duplicate_identifier(api_client, user, dandiset):
+    api_client.force_authenticate(user=user)
+    name = 'Test Dandiset'
+    identifier = dandiset.identifier
+    metadata = {'foo': 'bar', 'identifier': f'DANDI:{identifier}'}
+
+    response = api_client.post(
+        '/api/dandisets/',
+        {'name': name, 'metadata': metadata},
+        format='json',
+    )
+    assert response.status_code == 400
+    assert response.data == f'Dandiset {identifier} Already Exists'
+
+
+@pytest.mark.django_db
 def test_dandiset_rest_delete(api_client, dandiset, user):
     api_client.force_authenticate(user=user)
     assign_perm('owner', user, dandiset)

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -205,6 +205,22 @@ def test_dandiset_rest_create_with_duplicate_identifier(api_client, user, dandis
 
 
 @pytest.mark.django_db
+def test_dandiset_rest_create_with_invalid_identifier(api_client, user):
+    api_client.force_authenticate(user=user)
+    name = 'Test Dandiset'
+    identifier = 'abc123'
+    metadata = {'foo': 'bar', 'identifier': identifier}
+
+    response = api_client.post(
+        '/api/dandisets/',
+        {'name': name, 'metadata': metadata},
+        format='json',
+    )
+    assert response.status_code == 400
+    assert response.data == f'Invalid Identifier {identifier}'
+
+
+@pytest.mark.django_db
 def test_dandiset_rest_delete(api_client, dandiset, user):
     api_client.force_authenticate(user=user)
     assign_perm('owner', user, dandiset)

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -105,7 +105,6 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         try:
             dandiset.save(force_insert=True)
         except IntegrityError as e:
-            print(e.__cause__.pgcode)
             if e.__cause__.pgcode == '23505':
                 return Response(f'Dandiset {dandiset.identifier} Already Exists', status=400)
             raise e

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -99,12 +99,20 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             identifier = serializer.validated_data['metadata']['identifier']
             if identifier.startswith('DANDI:'):
                 identifier = identifier[6:]
-            dandiset = Dandiset(id=int(identifier))
+            try:
+                dandiset = Dandiset(id=int(identifier))
+            except ValueError:
+                return Response(f'Invalid Identifier {identifier}', status=400)
         else:
             dandiset = Dandiset()
         try:
+            # Without force_insert, Django will try to UPDATE an existing dandiset if one exists.
+            # We want to throw an error if a dandiset already exists.
             dandiset.save(force_insert=True)
         except IntegrityError as e:
+            # https://stackoverflow.com/questions/25368020/django-deduce-duplicate-key-exception-from-integrityerror
+            # https://www.postgresql.org/docs/13/errcodes-appendix.html
+            # Postgres error code 23505 == unique_violation
             if e.__cause__.pgcode == '23505':
                 return Response(f'Dandiset {dandiset.identifier} Already Exists', status=400)
             raise e


### PR DESCRIPTION
If `identifier` is in the metadata when creating a new dandiset, attempt to use that identifier instead of using the auto-incrementing sequence.