### PR TITLE
Staging area for uploaded blobs

### DIFF
--- a/dandiapi/api/copy.py
+++ b/dandiapi/api/copy.py
@@ -12,6 +12,9 @@ except ImportError:
     MinioStorage = type('FakeMinioStorage', (), {})
 
 
+PART_SIZE = 500 * 1024 * 1024  # 500 MB
+
+
 def copy_object(validation: Validation, dest_key: str):
     storage = Validation.blob.field.storage
     source_bucket = storage.bucket_name
@@ -37,12 +40,63 @@ def _copy_object_s3(
     # TODO This copy maxes out at 5GB. Use multipart copy API instead:
     # https://docs.aws.amazon.com/AmazonS3/latest/userguide/CopyingObjctsMPUapi.html
     client = storage.connection.meta.client
+
+    response = client.head_object(
+        Bucket=source_bucket,
+        Key=source_key,
+    )
+    content_length = response['ContentLength']
+
     copy_source = f'{source_bucket}/{source_key}'
-    client.copy_object(
+
+    # Use multipart copy so files > 5GB are supported
+
+    parts_count = content_length // PART_SIZE
+    if content_length % PART_SIZE > 0:
+        # The extra part is for the remaining bytes that might be less than PART_SIZE
+        parts_count += 1
+
+    response = client.create_multipart_upload(
         Bucket=dest_bucket,
         Key=dest_key,
-        CopySource=copy_source,
     )
+    upload_id = response['UploadId']
+
+    progress = 0
+    remaining = content_length
+    parts = []
+    for part_number in range(1, parts_count + 1):
+        # Calculate the range to be copied
+        if remaining > PART_SIZE:
+            copy_range = f'bytes={progress}-{progress+PART_SIZE-1}'
+            progress += PART_SIZE
+            remaining -= PART_SIZE
+        else:
+            copy_range = f'bytes={progress}-{content_length-1}'
+
+        # Copy the part
+        response = client.upload_part_copy(
+            Bucket=dest_bucket,
+            Key=dest_key,
+            UploadId=upload_id,
+            CopySource=copy_source,
+            CopySourceRange=copy_range,
+            PartNumber=part_number,
+        )
+
+        # Save the ETag + Part number
+        etag = response['CopyPartResult']['ETag']
+        parts += [{'ETag': etag, 'PartNumber': part_number}]
+
+    # Complete the multipart copy
+    client.complete_multipart_upload(
+        Bucket=dest_bucket,
+        Key=dest_key,
+        UploadId=upload_id,
+        MultipartUpload={'Parts': parts},
+    )
+
+    # Delete the original object
     client.delete_object(
         Bucket=source_bucket,
         Key=source_key,
@@ -56,8 +110,7 @@ def _copy_object_minio(
     dest_bucket: str,
     dest_key: str,
 ):
-    # TODO This copy maxes out at 5GB. Use multipart copy API instead:
-    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/CopyingObjctsMPUapi.html
+    # The Minio client will automatically use multipart upload if the file size is too big
     client = storage.client
     copy_source = f'{source_bucket}/{source_key}'
     client.copy_object(dest_bucket, dest_key, copy_source)

--- a/dandiapi/api/copy.py
+++ b/dandiapi/api/copy.py
@@ -1,0 +1,64 @@
+from dandiapi.api.models.validation import Validation
+
+try:
+    from storages.backends.s3boto3 import S3Boto3Storage
+except ImportError:
+    # This should only be used for type interrogation, never instantiation
+    S3Boto3Storage = type('FakeS3Boto3Storage', (), {})
+try:
+    from minio_storage.storage import MinioStorage
+except ImportError:
+    # This should only be used for type interrogation, never instantiation
+    MinioStorage = type('FakeMinioStorage', (), {})
+
+
+def copy_object(validation: Validation, dest_key: str):
+    storage = Validation.blob.field.storage
+    source_bucket = storage.bucket_name
+    # TODO: we may eventually want different buckets
+    dest_bucket = source_bucket
+    source_key = validation.blob.name
+
+    if isinstance(Validation.blob.field.storage, S3Boto3Storage):
+        _copy_object_s3(storage, source_bucket, source_key, dest_bucket, dest_key)
+    elif isinstance(Validation.blob.field.storage, MinioStorage):
+        _copy_object_minio(storage, source_bucket, source_key, dest_bucket, dest_key)
+    else:
+        raise ValueError(f'Unknown Validation storage {Validation.blob.field.storage}')
+
+
+def _copy_object_s3(
+    storage,
+    source_bucket: str,
+    source_key: str,
+    dest_bucket: str,
+    dest_key: str,
+):
+    # TODO This copy maxes out at 5GB. Use multipart copy API instead:
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/CopyingObjctsMPUapi.html
+    client = storage.connection.meta.client
+    copy_source = f'{source_bucket}/{source_key}'
+    client.copy_object(
+        Bucket=dest_bucket,
+        Key=dest_key,
+        CopySource=copy_source,
+    )
+    client.delete_object(
+        Bucket=source_bucket,
+        Key=source_key,
+    )
+
+
+def _copy_object_minio(
+    storage,
+    source_bucket: str,
+    source_key: str,
+    dest_bucket: str,
+    dest_key: str,
+):
+    # TODO This copy maxes out at 5GB. Use multipart copy API instead:
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/CopyingObjctsMPUapi.html
+    client = storage.client
+    copy_source = f'{source_bucket}/{source_key}'
+    client.copy_object(dest_bucket, dest_key, copy_source)
+    client.remove_object(source_bucket, source_key)

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -64,7 +64,9 @@ class AssetBlob(TimeStampedModel):
             return cls.objects.get(sha256=validation.sha256), False
         except cls.DoesNotExist:
             # Copy the data from the upload zone to the blob zone
-            destination = f'blobs/{validation.sha256}'
+            destination = (
+                f'blobs/{validation.sha256[0:3]}/{validation.sha256[3:6]}/{validation.sha256[6:]}'
+            )
             copy_object(validation, destination)
             return cls(blob=destination, sha256=validation.sha256), True
 

--- a/dandiapi/api/models/validation.py
+++ b/dandiapi/api/models/validation.py
@@ -16,7 +16,7 @@ def _get_validation_blob_storage() -> Storage:
 
 
 def _get_validation_blob_prefix(instance: Validation, filename: str) -> str:
-    return f'{filename}/{uuid4()}'
+    return f'uploads/{uuid4()}'
 
 
 class Validation(TimeStampedModel):

--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -48,7 +48,6 @@ def validate(validation_id: int) -> None:
         validation.error = None
         validation.save()
 
-        # TODO separate storages for Validations and Assets require a copy at this point
         asset_blob, created = AssetBlob.from_validation(validation)
         if created:
             asset_blob.save()

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from django.contrib.auth.models import User
 import factory
 
@@ -67,8 +69,12 @@ class AssetBlobFactory(factory.django.DjangoModelFactory):
         model = AssetBlob
 
     blob = factory.django.FileField(data=b'somefilebytes')
-    # TODO: This sha256 is technically invalid for the blob
-    sha256 = factory.Faker('sha256')
+
+    @factory.lazy_attribute
+    def sha256(self):
+        h = hashlib.sha256()
+        h.update(b'somefilebytes')
+        return h.hexdigest()
 
 
 class AssetMetadataFactory(factory.django.DjangoModelFactory):
@@ -93,7 +99,12 @@ class ValidationFactory(factory.django.DjangoModelFactory):
         model = Validation
 
     blob = factory.django.FileField(data=b'validationbytes')
-    # TODO: This sha256 is technically invalid for the blob
-    sha256 = factory.Faker('sha256')
+
+    @factory.lazy_attribute
+    def sha256(self):
+        h = hashlib.sha256()
+        h.update(b'validationbytes')
+        return h.hexdigest()
+
     state = 'SUCCEEDED'
     error = factory.Faker('sentence')

--- a/dandiapi/api/tests/test_copy.py
+++ b/dandiapi/api/tests/test_copy.py
@@ -1,0 +1,79 @@
+from typing import TYPE_CHECKING
+
+from botocore.exceptions import ClientError
+from django.conf import settings
+import pytest
+from storages.backends.s3boto3 import S3Boto3Storage
+
+from dandiapi.api.copy import _copy_object_s3, copy_object
+
+if TYPE_CHECKING:
+    # mypy_boto3_s3 only provides types
+    import mypy_boto3_s3 as s3
+
+
+def s3boto3_storage_factory() -> 'S3Boto3Storage':
+    storage = S3Boto3Storage(
+        access_key=settings.MINIO_STORAGE_ACCESS_KEY,
+        secret_key=settings.MINIO_STORAGE_SECRET_KEY,
+        region_name='test-region',
+        bucket_name=settings.MINIO_STORAGE_MEDIA_BUCKET_NAME,
+        # For testing, connect to a local Minio instance
+        endpoint_url=(
+            f'{"https" if settings.MINIO_STORAGE_USE_HTTPS else "http"}:'
+            f'//{settings.MINIO_STORAGE_ENDPOINT}'
+        ),
+    )
+
+    resource: s3.ServiceResource = storage.connection
+    client: s3.Client = resource.meta.client
+    try:
+        client.head_bucket(Bucket=settings.MINIO_STORAGE_MEDIA_BUCKET_NAME)
+    except ClientError:
+        client.create_bucket(Bucket=settings.MINIO_STORAGE_MEDIA_BUCKET_NAME)
+
+    return storage
+
+
+@pytest.mark.django_db
+def test_copy_minio(validation):
+    destination = 'blobs/test'
+
+    # Delete the blob if it is already present in the test storage
+    validation.blob.field.storage.delete(destination)
+    assert not validation.blob.field.storage.exists(destination)
+
+    copy_object(validation, destination)
+
+    # Verify object was copied
+    assert validation.blob.field.storage.exists(destination)
+
+    # Verify original object was deleted
+    assert not validation.blob.field.storage.exists(validation.blob.name)
+
+
+@pytest.mark.django_db
+def test_copy_s3(validation):
+    destination = 'blobs/test'
+
+    # Delete the blob if it is already present in the test storage
+    validation.blob.field.storage.delete(destination)
+    assert not validation.blob.field.storage.exists(destination)
+
+    # Rather than setting up an actual S3 storage, we just create an artificial S3Boto3Storage
+    # which is backed by the minio storage.
+    storage = s3boto3_storage_factory()
+    source_bucket = validation.blob.field.storage.bucket_name
+    # TODO: we may eventually want different buckets
+    dest_bucket = source_bucket
+    source_key = validation.blob.name
+
+    # Call the S3 copy method directly, as copy_object() would check the storage on the field and
+    # use _copy_object_minio instead.
+    _copy_object_s3(storage, source_bucket, source_key, dest_bucket, destination)
+
+    # Verify object was copied
+    assert validation.blob.field.storage.exists(destination)
+
+    # Verify original object was deleted
+    assert not validation.blob.field.storage.exists(validation.blob.name)

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -14,15 +14,14 @@ def mb(bytes_size: int) -> int:
 def test_upload_initialize(api_client, user):
     api_client.force_authenticate(user=user)
 
-    file_name = 'test.txt'
     file_size = 123
 
     assert api_client.post(
         '/api/uploads/initialize/',
-        {'file_name': file_name, 'file_size': file_size},
+        {'file_size': file_size},
         format='json',
     ).data == {
-        'object_key': Re(f'{file_name}/[a-z0-9\\-]+'),
+        'object_key': Re('uploads/[a-z0-9\\-]+'),
         'upload_id': UUID_RE,
         'parts': [
             {
@@ -84,12 +83,10 @@ def test_upload_complete_unauthorized(api_client):
 def test_upload_initialize_and_complete(api_client, user, file_size):
     api_client.force_authenticate(user=user)
 
-    file_name = 'upload-test.txt'
-
     # Get the presigned upload URL
     initialization = api_client.post(
         '/api/uploads/initialize/',
-        {'file_name': file_name, 'file_size': file_size},
+        {'file_size': file_size},
         format='json',
     ).data
 

--- a/dandiapi/api/tests/test_validate.py
+++ b/dandiapi/api/tests/test_validate.py
@@ -213,7 +213,7 @@ def test_validation_task():
 
     # Successful validations also write an AssetBlob
     asset_blob = AssetBlob.objects.get(sha256=sha256)
-    assert asset_blob.blob.name == f'blobs/{sha256}'
+    assert asset_blob.blob.name == f'blobs/{sha256[0:3]}/{sha256[3:6]}/{sha256[6:]}'
     assert asset_blob.blob.field.storage.exists(asset_blob.blob.name)
 
     # After copying the object, the original uploaded blob should be removed.

--- a/dandiapi/api/tests/test_validate.py
+++ b/dandiapi/api/tests/test_validate.py
@@ -46,7 +46,7 @@ def test_validate(api_client, user):
 @pytest.mark.parametrize(
     'contents', [b'Very little content!', b'X' * 1024, b'X' * 1024 * 16], ids=['20B', '1KB', '16KB']
 )
-def test_validate_no_object_key(api_client, user, state, contents):
+def test_validate_no_object_key(api_client, user, asset_blob_factory, state, contents):
     api_client.force_authenticate(user=user)
 
     object_key = 'test.txt'
@@ -60,6 +60,10 @@ def test_validate_no_object_key(api_client, user, state, contents):
     # Save an existing Validation that will be updated
     Validation(blob=object_key, sha256=sha256, state=state).save()
 
+    # Save an existing AssetBlob with the same checksum
+    asset_blob = asset_blob_factory(sha256=sha256)
+    asset_blob.save()
+
     assert (
         api_client.post(
             '/api/uploads/validate/',
@@ -72,7 +76,7 @@ def test_validate_no_object_key(api_client, user, state, contents):
     )
 
     validation = Validation.objects.get(sha256=sha256)
-    assert validation.blob.name == object_key
+    assert validation.blob.name == asset_blob.blob.name
     assert validation.state == Validation.State.IN_PROGRESS
 
 
@@ -208,7 +212,12 @@ def test_validation_task():
     assert validation.error is None
 
     # Successful validations also write an AssetBlob
-    assert AssetBlob.objects.get(sha256=sha256)
+    asset_blob = AssetBlob.objects.get(sha256=sha256)
+    assert asset_blob.blob.name == f'blobs/{sha256}'
+    assert asset_blob.blob.field.storage.exists(asset_blob.blob.name)
+
+    # After copying the object, the original uploaded blob should be removed.
+    assert not asset_blob.blob.field.storage.exists(validation.blob.name)
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -200,7 +200,6 @@ def test_version_rest_publish(api_client, user, version, asset_factory):
     assert version.assets.count() == published_version.assets.count()
     draft_asset = version.assets.first()
     published_asset = published_version.assets.first()
-    print(draft_asset, published_asset)
     assert draft_asset.uuid != published_asset.uuid
     assert draft_asset.path == published_asset.path
     assert draft_asset.metadata == published_asset.metadata

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -21,7 +21,6 @@ from dandiapi.api.views.serializers import ValidationErrorSerializer, Validation
 
 
 class UploadInitializationRequestSerializer(serializers.Serializer):
-    file_name = serializers.CharField(trim_whitespace=False)
     file_size = serializers.IntegerField(min_value=1)
 
 
@@ -68,6 +67,7 @@ class UploadValidationRequestSerializer(serializers.Serializer):
     object_key = serializers.CharField(trim_whitespace=False, required=False)
     sha256 = serializers.CharField(
         trim_whitespace=False,
+        required=True,
         validators=[RegexValidator(Validation.SHA256_REGEX)],
     )
 
@@ -96,8 +96,10 @@ def upload_initialize_view(request: Request) -> HttpResponseBase:
     # TODO The first argument to generate_filename() is an instance of the model.
     # We do not and will never have an instance of the model during field upload.
     # Maybe we need a different generate method/upload_to with a different signature?
+    # Since we are saving Validations with a UUID instead of a filename, we don't need
+    # any arguments at all.
     object_key = Validation.blob.field.storage.generate_filename(
-        Validation.blob.field.upload_to(None, upload_request['file_name'])
+        Validation.blob.field.upload_to(None, None)
     )
 
     initialization = MultipartManager.from_storage(Validation.blob.field.storage).initialize_upload(


### PR DESCRIPTION
Uploads now are now stored in the bucket at `uploads/{uuid}`, then are copied to `blobs/{sha256}` after validation succeeds.

This requires copying blobs, which is an operation that is not provided by anything we currently have installed, hence `copy.py`. After the copy is completed, the original blob is deleted to avoid keeping duplicate copies of all files.

Multipart copy is used to avoid the 5GB limit on normal copy operations.

@yarikoptic The only API change is that it will no longer be necessary to specify `filename` when calling `POST /uploads/initialize/`. Nothing will break if you continue to provide `filename`, it is simply no longer necessary.

@yarikoptic edit: likely Closes #114