### PR TITLE
Use the built-in JSONField from Django 3.1

### DIFF
--- a/dandiapi/api/migrations/0001_initial.py
+++ b/dandiapi/api/migrations/0001_initial.py
@@ -2,7 +2,6 @@
 
 import uuid
 
-import django.contrib.postgres.fields.jsonb
 import django.core.validators
 from django.db import migrations, models
 import django.db.models.deletion
@@ -86,7 +85,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     'metadata',
-                    django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict),
+                    models.JSONField(blank=True, default=dict),
                 ),
             ],
             options={
@@ -143,7 +142,7 @@ class Migration(migrations.Migration):
                         auto_now=True, verbose_name='modified'
                     ),
                 ),
-                ('metadata', django.contrib.postgres.fields.jsonb.JSONField(default=dict)),
+                ('metadata', models.JSONField(default=dict)),
                 ('name', models.CharField(max_length=300)),
             ],
             options={

--- a/dandiapi/api/migrations/0004_update_asset_model.py
+++ b/dandiapi/api/migrations/0004_update_asset_model.py
@@ -2,7 +2,6 @@
 
 import uuid
 
-import django.contrib.postgres.fields.jsonb
 from django.db import migrations, models
 
 
@@ -43,9 +42,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='assetmetadata',
             name='metadata',
-            field=django.contrib.postgres.fields.jsonb.JSONField(
-                blank=True, default=dict, unique=True
-            ),
+            field=models.JSONField(blank=True, default=dict, unique=True),
         ),
         migrations.AlterUniqueTogether(
             name='asset',

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -4,7 +4,6 @@ from typing import List, Set
 import uuid
 
 from django.conf import settings
-from django.contrib.postgres.fields import JSONField
 from django.contrib.postgres.indexes import HashIndex
 from django.core.files.storage import Storage
 from django.core.validators import RegexValidator
@@ -54,7 +53,7 @@ class AssetBlob(TimeStampedModel):
 
 
 class AssetMetadata(TimeStampedModel):
-    metadata = JSONField(blank=True, unique=True, default=dict)
+    metadata = models.JSONField(blank=True, unique=True, default=dict)
 
     @property
     def references(self) -> int:

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 
-from django.contrib.postgres.fields import JSONField
 from django.contrib.postgres.indexes import HashIndex
 from django.core.validators import RegexValidator
 from django.db import models
@@ -12,7 +11,7 @@ from .dandiset import Dandiset
 
 
 class VersionMetadata(TimeStampedModel):
-    metadata = JSONField(default=dict)
+    metadata = models.JSONField(default=dict)
     name = models.CharField(max_length=300)
 
     class Meta:


### PR DESCRIPTION
Importing from the old location is deprecated. A real migration is not necessary, since the old field wraps the new field, with a warning.