### PR TITLE
Enable Celery broker heartbeat

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: ./manage.py migrate
 web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi
-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat
+worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -49,6 +49,9 @@ class DandiMixin(ConfigMixin):
     DANDI_GIRDER_API_URL = values.URLValue(environ_required=True)
     DANDI_GIRDER_API_KEY = values.Value(environ_required=True)
 
+    # The CloudAMQP connection was dying, using the heartbeat should keep it alive
+    CELERY_BROKER_HEARTBEAT = 20
+
 
 class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
     pass


### PR DESCRIPTION
This may resolve the SSL_ERRORs happening during upload of large files by keeping the connection to the broker from dying.