### PR TITLE
Validation cleanup task

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: ./manage.py migrate
 web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi
-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO
+worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO --beat --scheduler django_celery_beat.schedulers:DatabaseScheduler

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -33,6 +33,7 @@ class DandiMixin(ConfigMixin):
         configuration.INSTALLED_APPS += [
             'guardian',
             'allauth.socialaccount.providers.github',
+            'django_celery_beat',
         ]
 
         configuration.AUTHENTICATION_BACKENDS += ['guardian.backends.ObjectPermissionBackend']

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'django>=3.1.2',
         'django-admin-display',
         'django-allauth',
+        'django-celery-beat',
         'django-configurations[database,email]',
         'django-extensions',
         'django-filter',


### PR DESCRIPTION
`django_celery_beat` stores scheduling in the DB, so once this is merged someone would add a schedule for the `clean_validations` task in the admin interface. `hours` is set as an argument there, so if we need to adjust the timing we can do it in a few clicks.