### PR TITLE
Only return asset metadata from GET .../assets/{uuid}

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -73,26 +73,13 @@ def test_asset_rest_retrieve(api_client, asset):
         f'/api/dandisets/{asset.version.dandiset.identifier}/'
         f'versions/{asset.version.version}/assets/{asset.uuid}/'
     ).data == {
-        'uuid': str(asset.uuid),
-        'path': asset.path,
-        'size': asset.size,
-        'sha256': asset.sha256,
-        'created': TIMESTAMP_RE,
-        'modified': TIMESTAMP_RE,
-        'version': {
-            'dandiset': {
-                'identifier': asset.version.dandiset.identifier,
-                'created': TIMESTAMP_RE,
-                'modified': TIMESTAMP_RE,
-            },
-            'version': asset.version.version,
-            'name': asset.version.name,
-            'created': TIMESTAMP_RE,
-            'modified': TIMESTAMP_RE,
-            'asset_count': 1,
-            'size': asset.size,
-        },
-        'metadata': asset.metadata.metadata,
+        **asset.metadata.metadata,
+        'identifier': str(asset.uuid),
+        'contentUrl': [
+            f'https://api.dandiarchive.org/api/dandisets/{asset.version.dandiset.identifier}'
+            f'/versions/{asset.version.version}/assets/{asset.uuid}/download/',
+            asset.blob.blob.url,
+        ],
     }
 
 

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -2,6 +2,7 @@ from django.core.validators import RegexValidator
 from django.db.utils import IntegrityError
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from django_filters import rest_framework as filters
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -46,6 +47,31 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
 
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = AssetFilter
+
+    @swagger_auto_schema(
+        responses={
+            200: 'The asset metadata.',
+        },
+    )
+    def retrieve(self, request, version__dandiset__pk, version__version, uuid):
+        asset = self.get_object()
+        # TODO use http://localhost:8000 for local deployments
+        download_url = 'https://api.dandiarchive.org' + reverse(
+            'asset-download',
+            kwargs={
+                'version__dandiset__pk': version__dandiset__pk,
+                'version__version': version__version,
+                'uuid': uuid,
+            },
+        )
+
+        blob_url = asset.blob.blob.url
+        metadata = {
+            **asset.metadata.metadata,
+            'identifier': uuid,
+            'contentUrl': [download_url, blob_url],
+        }
+        return Response(metadata, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
         request_body=AssetRequestSerializer(),


### PR DESCRIPTION
`identifier: {uuid}` and `contentUrl: [{download_url}, {blob_url}]` are
also injected into the asset metadata before the response is sent.

Fixes #136 