### PR TITLE
Strip double quotes from S3 ETags

### DIFF
--- a/dandiapi/api/models/upload.py
+++ b/dandiapi/api/models/upload.py
@@ -81,7 +81,12 @@ class Upload(TimeStampedModel):
                 Bucket=storage.bucket_name,
                 Key=self.blob.name,
             )
-            return response['ETag']
+            etag = response['ETag']
+            # S3 wraps the ETag in double quotes, so we need to strip them
+            if etag[0] == '"' and etag[-1] == '"':
+                return etag[1:-1]
+            return etag
+
         elif isinstance(storage, MinioStorage):
             client = storage.client
             response = client.stat_object(storage.bucket_name, self.blob.name)


### PR DESCRIPTION
https://github.com/dandi/dandi-cli/pull/479#issuecomment-805056962

S3 wraps ETags in double quotes, so strip them before testing that expected ETag matches actual ETag.