### PR TITLE
Optimize publish

### DIFF
--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -1,9 +1,11 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from django.core.files.base import ContentFile
 from django.db.transaction import atomic
+from rest_framework_yaml.renderers import YAMLRenderer
 
 from dandiapi.api.checksum import calculate_sha256_checksum
-from dandiapi.api.models import AssetBlob
+from dandiapi.api.models import AssetBlob, Version
 
 logger = get_task_logger(__name__)
 
@@ -23,3 +25,31 @@ def calculate_sha256(blob_id: int) -> None:
 
     asset_blob.sha256 = sha256
     asset_blob.save()
+
+
+@shared_task
+@atomic
+def write_yamls(version_id: int) -> None:
+    logger.info('Writing dandiset.yaml and assets.yaml for version %s', version_id)
+    version: Version = Version.objects.get(id=version_id)
+
+    # Piggyback on the AssetBlob storage since we want to store .yamls in the same bucket
+    storage = AssetBlob.blob.field.storage
+
+    dandiset_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
+    if storage.exists(dandiset_yaml_path):
+        logger.info('%s already exists, deleting it', dandiset_yaml_path)
+        storage.delete(dandiset_yaml_path)
+    logger.info('Saving %s', dandiset_yaml_path)
+    dandiset_yaml = YAMLRenderer().render(version.metadata.metadata)
+    storage.save(dandiset_yaml_path, ContentFile(dandiset_yaml))
+
+    assets_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    if storage.exists(assets_yaml_path):
+        logger.info('%s already exists, deleting it', assets_yaml_path)
+        storage.delete(assets_yaml_path)
+    logger.info('Saving %s', assets_yaml_path)
+    assets_yaml = YAMLRenderer().render([asset.metadata.metadata for asset in version.assets.all()])
+    storage.save(assets_yaml_path, ContentFile(assets_yaml))
+
+    logger.info('Wrote dandiset.yaml and assets.yaml for version %s', version_id)

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -1,10 +1,12 @@
 import hashlib
 
+from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 import pytest
+from rest_framework_yaml.renderers import YAMLRenderer
 
 from dandiapi.api import tasks
-from dandiapi.api.models import AssetBlob
+from dandiapi.api.models import AssetBlob, Version
 
 
 @pytest.mark.django_db
@@ -23,3 +25,75 @@ def test_calculate_checksum_task(storage: Storage, asset_blob_factory):
     asset_blob.refresh_from_db()
 
     assert asset_blob.sha256 == sha256
+
+
+@pytest.mark.django_db
+def test_write_dandiset_yaml(storage: Storage, version: Version):
+    # Pretend like AssetBlob was defined with the given storage
+    # The task piggybacks off of the AssetBlob storage to write the yamls
+    AssetBlob.blob.field.storage = storage
+
+    tasks.write_yamls(version.id)
+
+    dandiset_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
+    # TODO this will fail if the test is run twice in the same minute.
+    # The same version ID will be generated in the second test,
+    # but the dandiset.yaml will still be present from the first test, creating a mismatch.
+    # The solution is to remove the file if it already exists in models.Version.write_yamls().
+    with storage.open(dandiset_yaml_path) as f:
+        assert f.read() == YAMLRenderer().render(version.metadata.metadata)
+
+
+@pytest.mark.django_db
+def test_write_assets_yaml(storage: Storage, version: Version, asset_factory):
+    # Pretend like AssetBlob was defined with the given storage
+    # The task piggybacks off of the AssetBlob storage to write the yamls
+    AssetBlob.blob.field.storage = storage
+
+    # Create a new asset in the version so there is information to write
+    version.assets.add(asset_factory())
+
+    tasks.write_yamls(version.id)
+
+    assets_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    with storage.open(assets_yaml_path) as f:
+        assert f.read() == YAMLRenderer().render(
+            [asset.metadata.metadata for asset in version.assets.all()]
+        )
+
+
+@pytest.mark.django_db
+def test_write_dandiset_yaml_already_exists(storage: Storage, version: Version):
+    # Pretend like AssetBlob was defined with the given storage
+    # The task piggybacks off of the AssetBlob storage to write the yamls
+    AssetBlob.blob.field.storage = storage
+
+    # Save an invalid file for the task to overwrite
+    dandiset_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
+    storage.save(dandiset_yaml_path, ContentFile(b'wrong contents'))
+
+    tasks.write_yamls(version.id)
+
+    with storage.open(dandiset_yaml_path) as f:
+        assert f.read() == YAMLRenderer().render(version.metadata.metadata)
+
+
+@pytest.mark.django_db
+def test_write_assets_yaml_already_exists(storage: Storage, version: Version, asset_factory):
+    # Pretend like AssetBlob was defined with the given storage
+    # The task piggybacks off of the AssetBlob storage to write the yamls
+    AssetBlob.blob.field.storage = storage
+
+    # Create a new asset in the version so there is information to write
+    version.assets.add(asset_factory())
+
+    # Save an invalid file for the task to overwrite
+    assets_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    storage.save(assets_yaml_path, ContentFile(b'wrong contents'))
+
+    tasks.write_yamls(version.id)
+
+    with storage.open(assets_yaml_path) as f:
+        assert f.read() == YAMLRenderer().render(
+            [asset.metadata.metadata for asset in version.assets.all()]
+        )

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from guardian.shortcuts import assign_perm
 import pytest
-from rest_framework_yaml.renderers import YAMLRenderer
 
 from dandiapi.api.models import Version
 
@@ -205,14 +204,3 @@ def test_version_rest_publish(api_client, user, version, asset):
     assert asset == version.assets.get()
     assert asset == published_version.assets.get()
     assert asset.versions.count() == 2
-
-    # TODO this will fail if the test is run twice in the same minute.
-    # The same version ID will be generated in the second test,
-    # but the dandiset.yaml will still be present from the first test, creating a mismatch.
-    # The solution is to remove the file if it already exists in models.Version.write_yamls().
-    with published_version._yaml_storage.open(published_version._dandiset_yaml_path) as f:
-        assert f.read() == YAMLRenderer().render(published_version.metadata.metadata)
-    with published_version._yaml_storage.open(published_version._assets_yaml_path) as f:
-        assert f.read() == YAMLRenderer().render(
-            [asset.metadata.metadata for asset in published_version.assets.all()]
-        )

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -9,6 +9,7 @@ from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSe
 
 from dandiapi.api import doi
 from dandiapi.api.models import Version, VersionMetadata
+from dandiapi.api.tasks import write_yamls
 from dandiapi.api.views.common import DandiPagination
 from dandiapi.api.views.serializers import (
     VersionDetailSerializer,
@@ -87,7 +88,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
             ]
         )
 
-        new_version.write_yamls()
+        write_yamls.delay(new_version.save())
 
         serializer = VersionSerializer(new_version)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -88,7 +88,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
             ]
         )
 
-        write_yamls.delay(new_version.save())
+        write_yamls.delay(new_version.id)
 
         serializer = VersionSerializer(new_version)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
* Use `bulk_create` to make creating new `Version`s with lots of `Asset`s faster.
* Move DOI creation to a task so it doesn't block the `/publish` request.