### PR TITLE
Use DANDI CLI for calculating part sizes

### DIFF
--- a/dandiapi/api/models/upload.py
+++ b/dandiapi/api/models/upload.py
@@ -5,7 +5,8 @@ from uuid import uuid4
 from django.core.validators import RegexValidator
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
-from s3_file_field._multipart import MultipartManager
+
+from dandiapi.api.multipart import DandiMultipartManager
 
 from .asset import AssetBlob, get_asset_blob_prefix, get_asset_blob_storage
 
@@ -52,7 +53,7 @@ class Upload(TimeStampedModel):
     def initialize_multipart_upload(cls, etag, size):
         upload_id = uuid4()
         object_key = cls.object_key(upload_id)
-        multipart_initialization = MultipartManager.from_storage(
+        multipart_initialization = DandiMultipartManager.from_storage(
             AssetBlob.blob.field.storage
         ).initialize_upload(object_key, size)
 

--- a/dandiapi/api/multipart.py
+++ b/dandiapi/api/multipart.py
@@ -1,0 +1,51 @@
+from typing import Iterator, Tuple
+
+from dandi.core.digests.dandietag import PartGenerator
+from django.core.files.storage import Storage
+from s3_file_field._multipart import MultipartManager
+from s3_file_field._multipart_boto3 import Boto3MultipartManager
+from s3_file_field._multipart_minio import MinioMultipartManager
+
+
+class UnsupportedStorageException(Exception):
+    """Raised when MultipartManager does not support the given Storage."""
+
+    pass
+
+
+class IterPartSizesMixin:
+    @staticmethod
+    def _iter_part_sizes(file_size: int, part_size: int = None) -> Iterator[Tuple[int, int]]:
+        generator = PartGenerator.for_file_size(file_size)
+        for part in generator:
+            yield part.number, part.size
+
+
+class DandiBoto3MultipartManager(IterPartSizesMixin, Boto3MultipartManager):
+    pass
+
+
+class DandiMinioMultipartManager(IterPartSizesMixin, MinioMultipartManager):
+    pass
+
+
+class DandiMultipartManager(MultipartManager):
+    @classmethod
+    def from_storage(cls, storage: Storage) -> MultipartManager:
+        try:
+            from storages.backends.s3boto3 import S3Boto3Storage
+        except ImportError:
+            pass
+        else:
+            if isinstance(storage, S3Boto3Storage):
+                return DandiBoto3MultipartManager(storage)
+
+        try:
+            from minio_storage.storage import MinioStorage
+        except ImportError:
+            pass
+        else:
+            if isinstance(storage, MinioStorage):
+                return DandiMinioMultipartManager(storage)
+
+        raise UnsupportedStorageException('Unsupported storage provider.')

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
+        'dandi>=0.12.0',
         'django>=3.1.2',
         'django-admin-display',
         'django-allauth',


### PR DESCRIPTION
Fixes #160

@brianhelba no real review required, I just wanted you to see how I subclassed the `MultipartManager`. Because of how the factory method picks a different storage subclass, I had to override it to use our subclasses. If we want to support this general use case, the path of least resistance for subclassing could be improved.