### PR TITLE
No schema version

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 
-from django.conf import settings
 from django.contrib.postgres.indexes import HashIndex
 from django.core.validators import RegexValidator
 from django.db import models
@@ -92,7 +91,6 @@ class Version(TimeStampedModel):
                 **self.metadata.metadata,
                 'name': self.metadata.name,
                 'identifier': f'DANDI:{self.dandiset.identifier}',
-                'schema_version': settings.DANDI_SCHEMA_VERSION,
             },
         )
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -137,7 +137,7 @@ def test_dandiset_rest_create(api_client, user):
         **metadata,
         'name': name,
         'identifier': DANDISET_SCHEMA_ID_RE,
-        'schema_version': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
     }
 
 
@@ -187,7 +187,7 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
         **metadata,
         'name': name,
         'identifier': f'DANDI:{identifier}',
-        'schema_version': settings.DANDI_SCHEMA_VERSION,
+        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
     }
 
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from guardian.shortcuts import assign_perm
 import pytest
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -137,7 +137,6 @@ def test_dandiset_rest_create(api_client, user):
         **metadata,
         'name': name,
         'identifier': DANDISET_SCHEMA_ID_RE,
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
     }
 
 
@@ -187,7 +186,6 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
         **metadata,
         'name': name,
         'identifier': f'DANDI:{identifier}',
-        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
     }
 
 

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from guardian.shortcuts import assign_perm
 import pytest
 
@@ -104,7 +103,6 @@ def test_version_rest_update(api_client, user, version):
         **new_metadata,
         'name': new_name,
         'identifier': f'DANDI:{version.dandiset.identifier}',
-        'schema_version': settings.DANDI_SCHEMA_VERSION,
     }
 
     assert api_client.put(
@@ -147,7 +145,6 @@ def test_version_rest_update_large(api_client, user, version):
         **new_metadata,
         'name': new_name,
         'identifier': f'DANDI:{version.dandiset.identifier}',
-        'schema_version': settings.DANDI_SCHEMA_VERSION,
     }
 
     assert api_client.put(

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -91,10 +91,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         serializer.is_valid(raise_exception=True)
 
         name = serializer.validated_data['name']
-        metadata = {
-            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
-            **serializer.validated_data['metadata'],
-        }
+        metadata = serializer.validated_data['metadata']
 
         version_metadata, created = VersionMetadata.objects.get_or_create(
             name=name,

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import OuterRef, Subquery
 from django.db.utils import IntegrityError

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import OuterRef, Subquery
 from django.db.utils import IntegrityError
@@ -89,9 +90,15 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
+        name = serializer.validated_data['name']
+        metadata = {
+            'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+            **serializer.validated_data['metadata'],
+        }
+
         version_metadata, created = VersionMetadata.objects.get_or_create(
-            name=serializer.validated_data['name'],
-            metadata=serializer.validated_data['metadata'],
+            name=name,
+            metadata=metadata,
         )
         if created:
             version_metadata.save()


### PR DESCRIPTION
Fixes #172

* Rename `schema_version` to `schemaVersion` in version metadata.
* No longer inject `schemaVersion` to the version metadata whenever the version is saved.
* Inject `schemaVersion` into the version metadata when creating the initial metadata during dandiset creation. The API can also specify a `schemaVersion` in the metadata when calling `POST /dandisets/`, which will take precedence.

@satra @yarikoptic does that change list sound right?