### PR TITLE
Lock down publish

### DIFF
--- a/dandiapi/api/tests/conftest.py
+++ b/dandiapi/api/tests/conftest.py
@@ -31,13 +31,18 @@ register(AssetFactory)
 register(AssetBlobFactory)
 register(AssetMetadataFactory)
 register(DandisetFactory)
-register(PublishedVersionFactory)
-register(DraftVersionFactory)
+register(PublishedVersionFactory, _name='published_version')
+register(DraftVersionFactory, _name='draft_version')
 # registering DraftVersionFactory after PublishedVersionFactory means
 # the fixture `version` will always be a draft
 register(UserFactory)
 register(UploadFactory)
 register(VersionMetadataFactory)
+
+
+@pytest.fixture(params=[DraftVersionFactory, PublishedVersionFactory], ids=['draft', 'published'])
+def version(request):
+    return request.param()
 
 
 @pytest.fixture

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -63,6 +63,11 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     @method_decorator(permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk')))
     def publish(self, request, **kwargs):
         old_version = self.get_object()
+        if old_version.version != 'draft':
+            return Response(
+                'Only draft versions can be published',
+                status=status.HTTP_405_METHOD_NOT_ALLOWED,
+            )
 
         new_version = Version.copy(old_version)
 

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -41,12 +41,6 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
         """Update the metadata of a version."""
         version: Version = self.get_object()
 
-        # TODO @permission_required doesn't work on methods
-        # https://github.com/django-guardian/django-guardian/issues/723
-        response = get_40x_or_None(request, ['owner'], version.dandiset, return_403=True)
-        if response:
-            return response
-
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -1,7 +1,6 @@
 from django.utils.decorators import method_decorator
 from drf_yasg.utils import no_body, swagger_auto_schema
 from guardian.decorators import permission_required_or_403
-from guardian.utils import get_40x_or_None
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticatedOrReadOnly

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -62,6 +62,10 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     @action(detail=True, methods=['POST'])
     @method_decorator(permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk')))
     def publish(self, request, **kwargs):
+        # TODO remove this check once publish is allowed
+        if not request.user.is_superuser:
+            return Response('Must be an admin to publish', status=status.HTTP_403_FORBIDDEN)
+
         old_version = self.get_object()
         if old_version.version != 'draft':
             return Response(


### PR DESCRIPTION
* Only drafts can be published
* Only admins can publish (for now, this will be reverted when publish is ready)
* The `version` fixture now runs tests twice, once with a draft version and once with a published version. The `published_version` and `draft_version` fixtures can be used if you need a specific version.