### PR TITLE
Rename `most_recent_version` and add `draft_version`

### DIFF
--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -10,18 +10,18 @@ def build_message(subject, message, to, html_message):
 
 
 def removed_subject(dandiset):
-    return f'Removed from Dandiset "{dandiset.most_recent_published_version.name}"'
+    return f'Removed from Dandiset "{dandiset.draft_version.name}"'
 
 
 def removed_message(dandiset):
-    return f'You have been removed as an owner of Dandiset "{dandiset.most_recent_published_version.name}".'
+    return f'You have been removed as an owner of Dandiset "{dandiset.draft_version.name}".'
 
 
 def removed_html_message(dandiset):
     return (
         'You have been removed as an owner of Dandiset '
         f'<a href="https://dandiarchive.org/dandiset/{dandiset.identifier}">'
-        f'{dandiset.most_recent_published_version.name}'
+        f'{dandiset.draft_version.name}'
         '</a>.'
     )
 
@@ -36,18 +36,18 @@ def build_removed_message(dandiset, removed_owner):
 
 
 def added_subject(dandiset):
-    return f'Added to Dandiset "{dandiset.most_recent_published_version.name}"'
+    return f'Added to Dandiset "{dandiset.draft_version.name}"'
 
 
 def added_message(dandiset):
-    return f'You have been made an owner of Dandiset "{dandiset.most_recent_published_version.name}".'
+    return f'You have been made an owner of Dandiset "{dandiset.draft_version.name}".'
 
 
 def added_html_message(dandiset):
     return (
         'You have been made an owner of Dandiset '
         f'<a href="https://dandiarchive.org/dandiset/{dandiset.identifier}">'
-        f'{dandiset.most_recent_published_version.name}'
+        f'{dandiset.draft_version.name}'
         '</a>.'
     )
 

--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -10,18 +10,18 @@ def build_message(subject, message, to, html_message):
 
 
 def removed_subject(dandiset):
-    return f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
+    return f'Removed from Dandiset "{dandiset.most_recent_published_version.name}"'
 
 
 def removed_message(dandiset):
-    return f'You have been removed as an owner of Dandiset "{dandiset.most_recent_version.name}".'
+    return f'You have been removed as an owner of Dandiset "{dandiset.most_recent_published_version.name}".'
 
 
 def removed_html_message(dandiset):
     return (
         'You have been removed as an owner of Dandiset '
         f'<a href="https://dandiarchive.org/dandiset/{dandiset.identifier}">'
-        f'{dandiset.most_recent_version.name}'
+        f'{dandiset.most_recent_published_version.name}'
         '</a>.'
     )
 
@@ -36,18 +36,18 @@ def build_removed_message(dandiset, removed_owner):
 
 
 def added_subject(dandiset):
-    return f'Added to Dandiset "{dandiset.most_recent_version.name}"'
+    return f'Added to Dandiset "{dandiset.most_recent_published_version.name}"'
 
 
 def added_message(dandiset):
-    return f'You have been made an owner of Dandiset "{dandiset.most_recent_version.name}".'
+    return f'You have been made an owner of Dandiset "{dandiset.most_recent_published_version.name}".'
 
 
 def added_html_message(dandiset):
     return (
         'You have been made an owner of Dandiset '
         f'<a href="https://dandiarchive.org/dandiset/{dandiset.identifier}">'
-        f'{dandiset.most_recent_version.name}'
+        f'{dandiset.most_recent_published_version.name}'
         '</a>.'
     )
 

--- a/dandiapi/api/models/dandiset.py
+++ b/dandiapi/api/models/dandiset.py
@@ -21,12 +21,11 @@ class Dandiset(TimeStampedModel):
 
     @property
     def most_recent_published_version(self):
-        version = self.versions.order_by('modified').last()
-        return None if version.version == 'draft' else version
+        return self.versions.exclude(version='draft').order_by('modified').last()
 
     @property
     def draft_version(self):
-        return self.versions.order_by('modified').last()
+        return self.versions.filter(version='draft').get()
 
     @property
     def owners(self):

--- a/dandiapi/api/models/dandiset.py
+++ b/dandiapi/api/models/dandiset.py
@@ -20,7 +20,7 @@ class Dandiset(TimeStampedModel):
         return f'{self.id:06}' if self.id is not None else ''
 
     @property
-    def most_recent_version(self):
+    def most_recent_published_version(self):
         return self.versions.order_by('created').last()
 
     @property

--- a/dandiapi/api/models/dandiset.py
+++ b/dandiapi/api/models/dandiset.py
@@ -21,7 +21,12 @@ class Dandiset(TimeStampedModel):
 
     @property
     def most_recent_published_version(self):
-        return self.versions.order_by('created').last()
+        version = self.versions.order_by('modified').last()
+        return None if version.version == 'draft' else version
+
+    @property
+    def draft_version(self):
+        return self.versions.order_by('modified').last()
 
     @property
     def owners(self):

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -328,8 +328,8 @@ def test_dandiset_rest_get_owners(api_client, dandiset, user):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_change_owner(api_client, version, user_factory, mailoutbox):
-    dandiset = version.dandiset
+def test_dandiset_rest_change_owner(api_client, draft_version, user_factory, mailoutbox):
+    dandiset = draft_version.dandiset
     user1 = user_factory()
     user2 = user_factory()
     assign_perm('owner', user1, dandiset)
@@ -353,8 +353,8 @@ def test_dandiset_rest_change_owner(api_client, version, user_factory, mailoutbo
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_add_owner(api_client, version, user_factory, mailoutbox):
-    dandiset = version.dandiset
+def test_dandiset_rest_add_owner(api_client, draft_version, user_factory, mailoutbox):
+    dandiset = draft_version.dandiset
     user1 = user_factory()
     user2 = user_factory()
     assign_perm('owner', user1, dandiset)
@@ -376,8 +376,8 @@ def test_dandiset_rest_add_owner(api_client, version, user_factory, mailoutbox):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_remove_owner(api_client, version, user_factory, mailoutbox):
-    dandiset = version.dandiset
+def test_dandiset_rest_remove_owner(api_client, draft_version, user_factory, mailoutbox):
+    dandiset = draft_version.dandiset
     user1 = user_factory()
     user2 = user_factory()
     assign_perm('owner', user1, dandiset)
@@ -465,14 +465,14 @@ def test_dandiset_rest_search_empty_query(api_client):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_search_identifier(api_client, version):
-    results = api_client.get('/api/dandisets/', {'search': version.dandiset.identifier}).data[
+def test_dandiset_rest_search_identifier(api_client, draft_version):
+    results = api_client.get('/api/dandisets/', {'search': draft_version.dandiset.identifier}).data[
         'results'
     ]
     assert len(results) == 1
-    assert results[0]['identifier'] == version.dandiset.identifier
+    assert results[0]['identifier'] == draft_version.dandiset.identifier
 
     assert results[0]['most_recent_published_version'] is None
 
-    assert results[0]['draft_version']['version'] == version.version
-    assert results[0]['draft_version']['name'] == version.name
+    assert results[0]['draft_version']['version'] == draft_version.version
+    assert results[0]['draft_version']['name'] == draft_version.name

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -250,7 +250,7 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
 
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
-    assert dandiset.most_recent_published_version == None
+    assert dandiset.most_recent_published_version is None
     assert dandiset.draft_version.version == 'draft'
     assert dandiset.draft_version.metadata.name == name
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -50,7 +50,9 @@ def test_dandiset_rest_list(api_client, dandiset):
 
 
 @pytest.mark.django_db
-def test_dandiset_versions(api_client, dandiset_factory, draft_version_factory, published_version_factory):
+def test_dandiset_versions(
+    api_client, dandiset_factory, draft_version_factory, published_version_factory
+):
     # Create some dandisets of different kinds.
     #
     # Empty dandiset.

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -50,6 +50,55 @@ def test_dandiset_rest_list(api_client, dandiset):
 
 
 @pytest.mark.django_db
+def test_dandiset_versions(api_client, dandiset_factory, draft_version_factory, published_version_factory):
+    # Create some dandisets of different kinds.
+    #
+    # Empty dandiset.
+    empty = dandiset_factory()
+
+    # Dandiset with a draft version only.
+    draft = draft_version_factory().dandiset
+
+    # Dandiset with a draft version and a published version.
+    published = published_version_factory().dandiset
+
+    data = api_client.get('/api/dandisets/').data
+
+    assert data['count'] == 3
+    assert data['next'] == None
+    assert data['previous'] == None
+
+    result0 = data['results'][0]
+    assert result0['identifier'] == empty.identifier
+    assert result0['created'] == TIMESTAMP_RE
+    assert result0['modified'] == TIMESTAMP_RE
+    assert result0['draft_version'] == None
+    assert result0['most_recent_published_version'] == None
+
+    result1 = data['results'][1]
+    assert result1['identifier'] == draft.identifier
+    assert result1['created'] == TIMESTAMP_RE
+    assert result1['modified'] == TIMESTAMP_RE
+    assert result1['most_recent_published_version'] == None
+    result1_draft = result1['draft_version']
+    assert result1_draft['version'] == draft.draft_version.version
+    assert result1_draft['name'] == draft.draft_version.name
+    assert result1_draft['asset_count'] == draft.draft_version.asset_count
+    assert result1_draft['size'] == draft.draft_version.size
+
+    result2 = data['results'][2]
+    assert result2['identifier'] == published.identifier
+    assert result2['created'] == TIMESTAMP_RE
+    assert result2['modified'] == TIMESTAMP_RE
+    assert result2['draft_version'] == None
+    result2_published = result2['most_recent_published_version']
+    assert result2_published['version'] == published.most_recent_published_version.version
+    assert result2_published['name'] == published.most_recent_published_version.name
+    assert result2_published['asset_count'] == published.most_recent_published_version.asset_count
+    assert result2_published['size'] == published.most_recent_published_version.size
+
+
+@pytest.mark.django_db
 def test_dandiset_rest_list_for_user(api_client, user, dandiset_factory):
     dandiset = dandiset_factory()
     # Create an extra dandiset that should not be included in the response

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -43,6 +43,7 @@ def test_dandiset_rest_list(api_client, dandiset):
                 'created': TIMESTAMP_RE,
                 'modified': TIMESTAMP_RE,
                 'draft_version': None,
+                'most_recent_published_version': None,
             }
         ],
     }
@@ -65,6 +66,7 @@ def test_dandiset_rest_list_for_user(api_client, user, dandiset_factory):
                 'created': TIMESTAMP_RE,
                 'modified': TIMESTAMP_RE,
                 'draft_version': None,
+                'most_recent_published_version': None,
             }
         ],
     }
@@ -77,6 +79,7 @@ def test_dandiset_rest_retrieve(api_client, dandiset):
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
         'draft_version': None,
+        'most_recent_published_version': None,
     }
 
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -470,7 +470,7 @@ def test_dandiset_rest_search_identifier(api_client, version):
     assert len(results) == 1
     assert results[0]['identifier'] == version.dandiset.identifier
 
-    assert results[0]['most_recent_published_version'] == None
+    assert results[0]['most_recent_published_version'] is None
 
     assert results[0]['draft_version']['version'] == version.version
     assert results[0]['draft_version']['name'] == version.name

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -201,7 +201,7 @@ def test_dandiset_rest_create(api_client, user):
 
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
-    assert dandiset.most_recent_published_version == None
+    assert dandiset.most_recent_published_version is None
     assert dandiset.draft_version.version == 'draft'
     assert dandiset.draft_version.metadata.name == name
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -59,7 +59,7 @@ def test_dandiset_versions(api_client, dandiset_factory, draft_version_factory, 
     # Dandiset with a draft version only.
     draft = draft_version_factory().dandiset
 
-    # Dandiset with a draft version and a published version.
+    # Dandiset with a published version only.
     published = published_version_factory().dandiset
 
     assert api_client.get('/api/dandisets/').data == {

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -42,7 +42,7 @@ def test_dandiset_rest_list(api_client, dandiset):
                 'identifier': dandiset.identifier,
                 'created': TIMESTAMP_RE,
                 'modified': TIMESTAMP_RE,
-                'most_recent_version': None,
+                'most_recent_published_version': None,
             }
         ],
     }
@@ -64,7 +64,7 @@ def test_dandiset_rest_list_for_user(api_client, user, dandiset_factory):
                 'identifier': dandiset.identifier,
                 'created': TIMESTAMP_RE,
                 'modified': TIMESTAMP_RE,
-                'most_recent_version': None,
+                'most_recent_published_version': None,
             }
         ],
     }
@@ -76,18 +76,18 @@ def test_dandiset_rest_retrieve(api_client, dandiset):
         'identifier': dandiset.identifier,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
-        'most_recent_version': None,
+        'most_recent_published_version': None,
     }
 
 
 """
 
-                'most_recent_version': {
-                    'version': dandiset.most_recent_version.version,
-                    'name': dandiset.most_recent_version.name,
-                    'asset_count': dandiset.most_recent_version.asset_count,
-                    'size': dandiset.most_recent_version.size,
-                    'metadata': dandiset.most_recent_version.metadata,
+                'most_recent_published_version': {
+                    'version': dandiset.most_recent_published_version.version,
+                    'name': dandiset.most_recent_published_version.name,
+                    'asset_count': dandiset.most_recent_published_version.asset_count,
+                    'size': dandiset.most_recent_published_version.size,
+                    'metadata': dandiset.most_recent_published_version.metadata,
                 },
 """
 
@@ -105,7 +105,7 @@ def test_dandiset_rest_create(api_client, user):
         'identifier': DANDISET_ID_RE,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
-        'most_recent_version': {
+        'most_recent_published_version': {
             'version': 'draft',
             'name': name,
             'asset_count': 0,
@@ -128,11 +128,11 @@ def test_dandiset_rest_create(api_client, user):
 
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
-    assert dandiset.most_recent_version.version == 'draft'
-    assert dandiset.most_recent_version.metadata.name == name
+    assert dandiset.most_recent_published_version.version == 'draft'
+    assert dandiset.most_recent_published_version.metadata.name == name
 
     # Verify that name and identifier were injected
-    assert dandiset.most_recent_version.metadata.metadata == {
+    assert dandiset.most_recent_published_version.metadata.metadata == {
         **metadata,
         'name': name,
         'identifier': DANDISET_SCHEMA_ID_RE,
@@ -155,7 +155,7 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
         'identifier': identifier,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
-        'most_recent_version': {
+        'most_recent_published_version': {
             'version': 'draft',
             'name': name,
             'asset_count': 0,
@@ -177,11 +177,11 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
 
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
-    assert dandiset.most_recent_version.version == 'draft'
-    assert dandiset.most_recent_version.metadata.name == name
+    assert dandiset.most_recent_published_version.version == 'draft'
+    assert dandiset.most_recent_published_version.metadata.name == name
 
     # Verify that name and identifier were injected
-    assert dandiset.most_recent_version.metadata.metadata == {
+    assert dandiset.most_recent_published_version.metadata.metadata == {
         **metadata,
         'name': name,
         'identifier': f'DANDI:{identifier}',
@@ -270,9 +270,9 @@ def test_dandiset_rest_change_owner(api_client, version, user_factory, mailoutbo
     assert list(dandiset.owners) == [user2]
 
     assert len(mailoutbox) == 2
-    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
+    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_published_version.name}"'
     assert mailoutbox[0].to == [user1.email]
-    assert mailoutbox[1].subject == f'Added to Dandiset "{dandiset.most_recent_version.name}"'
+    assert mailoutbox[1].subject == f'Added to Dandiset "{dandiset.most_recent_published_version.name}"'
     assert mailoutbox[1].to == [user2.email]
 
 
@@ -295,7 +295,7 @@ def test_dandiset_rest_add_owner(api_client, version, user_factory, mailoutbox):
     assert list(dandiset.owners) == [user1, user2]
 
     assert len(mailoutbox) == 1
-    assert mailoutbox[0].subject == f'Added to Dandiset "{dandiset.most_recent_version.name}"'
+    assert mailoutbox[0].subject == f'Added to Dandiset "{dandiset.most_recent_published_version.name}"'
     assert mailoutbox[0].to == [user2.email]
 
 
@@ -319,7 +319,7 @@ def test_dandiset_rest_remove_owner(api_client, version, user_factory, mailoutbo
     assert list(dandiset.owners) == [user1]
 
     assert len(mailoutbox) == 1
-    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_version.name}"'
+    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_published_version.name}"'
     assert mailoutbox[0].to == [user2.email]
 
 
@@ -395,5 +395,5 @@ def test_dandiset_rest_search_identifier(api_client, version):
     ]
     assert len(results) == 1
     assert results[0]['identifier'] == version.dandiset.identifier
-    assert results[0]['most_recent_version']['version'] == version.version
-    assert results[0]['most_recent_version']['name'] == version.name
+    assert results[0]['most_recent_published_version']['version'] == version.version
+    assert results[0]['most_recent_published_version']['name'] == version.name

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -42,7 +42,7 @@ def test_dandiset_rest_list(api_client, dandiset):
                 'identifier': dandiset.identifier,
                 'created': TIMESTAMP_RE,
                 'modified': TIMESTAMP_RE,
-                'most_recent_published_version': None,
+                'draft_version': None,
             }
         ],
     }
@@ -64,7 +64,7 @@ def test_dandiset_rest_list_for_user(api_client, user, dandiset_factory):
                 'identifier': dandiset.identifier,
                 'created': TIMESTAMP_RE,
                 'modified': TIMESTAMP_RE,
-                'most_recent_published_version': None,
+                'draft_version': None,
             }
         ],
     }
@@ -76,7 +76,7 @@ def test_dandiset_rest_retrieve(api_client, dandiset):
         'identifier': dandiset.identifier,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
-        'most_recent_published_version': None,
+        'draft_version': None,
     }
 
 
@@ -105,7 +105,7 @@ def test_dandiset_rest_create(api_client, user):
         'identifier': DANDISET_ID_RE,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
-        'most_recent_published_version': {
+        'draft_version': {
             'version': 'draft',
             'name': name,
             'asset_count': 0,
@@ -118,6 +118,7 @@ def test_dandiset_rest_create(api_client, user):
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
         },
+        'most_recent_published_version': None,
     }
     id = int(response.data['identifier'])
 
@@ -128,11 +129,12 @@ def test_dandiset_rest_create(api_client, user):
 
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
-    assert dandiset.most_recent_published_version.version == 'draft'
-    assert dandiset.most_recent_published_version.metadata.name == name
+    assert dandiset.most_recent_published_version == None
+    assert dandiset.draft_version.version == 'draft'
+    assert dandiset.draft_version.metadata.name == name
 
     # Verify that name and identifier were injected
-    assert dandiset.most_recent_published_version.metadata.metadata == {
+    assert dandiset.draft_version.metadata.metadata == {
         **metadata,
         'name': name,
         'identifier': DANDISET_SCHEMA_ID_RE,
@@ -155,7 +157,8 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
         'identifier': identifier,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
-        'most_recent_published_version': {
+        'most_recent_published_version': None,
+        'draft_version': {
             'version': 'draft',
             'name': name,
             'asset_count': 0,
@@ -177,11 +180,12 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
 
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
-    assert dandiset.most_recent_published_version.version == 'draft'
-    assert dandiset.most_recent_published_version.metadata.name == name
+    assert dandiset.most_recent_published_version == None
+    assert dandiset.draft_version.version == 'draft'
+    assert dandiset.draft_version.metadata.name == name
 
     # Verify that name and identifier were injected
-    assert dandiset.most_recent_published_version.metadata.metadata == {
+    assert dandiset.draft_version.metadata.metadata == {
         **metadata,
         'name': name,
         'identifier': f'DANDI:{identifier}',
@@ -270,9 +274,9 @@ def test_dandiset_rest_change_owner(api_client, version, user_factory, mailoutbo
     assert list(dandiset.owners) == [user2]
 
     assert len(mailoutbox) == 2
-    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_published_version.name}"'
+    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.draft_version.name}"'
     assert mailoutbox[0].to == [user1.email]
-    assert mailoutbox[1].subject == f'Added to Dandiset "{dandiset.most_recent_published_version.name}"'
+    assert mailoutbox[1].subject == f'Added to Dandiset "{dandiset.draft_version.name}"'
     assert mailoutbox[1].to == [user2.email]
 
 
@@ -295,7 +299,7 @@ def test_dandiset_rest_add_owner(api_client, version, user_factory, mailoutbox):
     assert list(dandiset.owners) == [user1, user2]
 
     assert len(mailoutbox) == 1
-    assert mailoutbox[0].subject == f'Added to Dandiset "{dandiset.most_recent_published_version.name}"'
+    assert mailoutbox[0].subject == f'Added to Dandiset "{dandiset.draft_version.name}"'
     assert mailoutbox[0].to == [user2.email]
 
 
@@ -319,7 +323,7 @@ def test_dandiset_rest_remove_owner(api_client, version, user_factory, mailoutbo
     assert list(dandiset.owners) == [user1]
 
     assert len(mailoutbox) == 1
-    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.most_recent_published_version.name}"'
+    assert mailoutbox[0].subject == f'Removed from Dandiset "{dandiset.draft_version.name}"'
     assert mailoutbox[0].to == [user2.email]
 
 
@@ -395,5 +399,8 @@ def test_dandiset_rest_search_identifier(api_client, version):
     ]
     assert len(results) == 1
     assert results[0]['identifier'] == version.dandiset.identifier
-    assert results[0]['most_recent_published_version']['version'] == version.version
-    assert results[0]['most_recent_published_version']['name'] == version.name
+
+    assert results[0]['most_recent_published_version'] == None
+
+    assert results[0]['draft_version']['version'] == version.version
+    assert results[0]['draft_version']['name'] == version.name

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -62,40 +62,58 @@ def test_dandiset_versions(api_client, dandiset_factory, draft_version_factory, 
     # Dandiset with a draft version and a published version.
     published = published_version_factory().dandiset
 
-    data = api_client.get('/api/dandisets/').data
-
-    assert data['count'] == 3
-    assert data['next'] == None
-    assert data['previous'] == None
-
-    result0 = data['results'][0]
-    assert result0['identifier'] == empty.identifier
-    assert result0['created'] == TIMESTAMP_RE
-    assert result0['modified'] == TIMESTAMP_RE
-    assert result0['draft_version'] == None
-    assert result0['most_recent_published_version'] == None
-
-    result1 = data['results'][1]
-    assert result1['identifier'] == draft.identifier
-    assert result1['created'] == TIMESTAMP_RE
-    assert result1['modified'] == TIMESTAMP_RE
-    assert result1['most_recent_published_version'] == None
-    result1_draft = result1['draft_version']
-    assert result1_draft['version'] == draft.draft_version.version
-    assert result1_draft['name'] == draft.draft_version.name
-    assert result1_draft['asset_count'] == draft.draft_version.asset_count
-    assert result1_draft['size'] == draft.draft_version.size
-
-    result2 = data['results'][2]
-    assert result2['identifier'] == published.identifier
-    assert result2['created'] == TIMESTAMP_RE
-    assert result2['modified'] == TIMESTAMP_RE
-    assert result2['draft_version'] == None
-    result2_published = result2['most_recent_published_version']
-    assert result2_published['version'] == published.most_recent_published_version.version
-    assert result2_published['name'] == published.most_recent_published_version.name
-    assert result2_published['asset_count'] == published.most_recent_published_version.asset_count
-    assert result2_published['size'] == published.most_recent_published_version.size
+    assert api_client.get('/api/dandisets/').data == {
+        'count': 3,
+        'next': None,
+        'previous': None,
+        'results': [
+            {
+                'identifier': empty.identifier,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+                'draft_version': None,
+                'most_recent_published_version': None,
+            },
+            {
+                'identifier': draft.identifier,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+                'draft_version': {
+                    'version': draft.draft_version.version,
+                    'name': draft.draft_version.name,
+                    'asset_count': draft.draft_version.asset_count,
+                    'size': draft.draft_version.size,
+                    'created': TIMESTAMP_RE,
+                    'modified': TIMESTAMP_RE,
+                    'dandiset': {
+                        'identifier': draft.identifier,
+                        'created': TIMESTAMP_RE,
+                        'modified': TIMESTAMP_RE,
+                    },
+                },
+                'most_recent_published_version': None,
+            },
+            {
+                'identifier': published.identifier,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+                'draft_version': None,
+                'most_recent_published_version': {
+                    'version': published.most_recent_published_version.version,
+                    'name': published.most_recent_published_version.name,
+                    'asset_count': published.most_recent_published_version.asset_count,
+                    'size': published.most_recent_published_version.size,
+                    'created': TIMESTAMP_RE,
+                    'modified': TIMESTAMP_RE,
+                    'dandiset': {
+                        'identifier': published.identifier,
+                        'created': TIMESTAMP_RE,
+                        'modified': TIMESTAMP_RE,
+                    },
+                },
+            },
+        ],
+    }
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -57,9 +57,10 @@ class VersionSerializer(serializers.ModelSerializer):
 
 class DandisetDetailSerializer(DandisetSerializer):
     class Meta(DandisetSerializer.Meta):
-        fields = DandisetSerializer.Meta.fields + ['most_recent_published_version']
+        fields = DandisetSerializer.Meta.fields + ['most_recent_published_version', 'draft_version']
 
     most_recent_published_version = VersionSerializer(read_only=True)
+    draft_version = VersionSerializer(read_only=True)
 
 
 class VersionDetailSerializer(VersionSerializer):

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -57,9 +57,9 @@ class VersionSerializer(serializers.ModelSerializer):
 
 class DandisetDetailSerializer(DandisetSerializer):
     class Meta(DandisetSerializer.Meta):
-        fields = DandisetSerializer.Meta.fields + ['most_recent_version']
+        fields = DandisetSerializer.Meta.fields + ['most_recent_published_version']
 
-    most_recent_version = VersionSerializer(read_only=True)
+    most_recent_published_version = VersionSerializer(read_only=True)
 
 
 class VersionDetailSerializer(VersionSerializer):


### PR DESCRIPTION
Begins addressing #188.

Breaks `most_recent_version` into two properties: `most_recent_published_version`, which can be `None`, and `draft_version`, which is never `None`.

This is ready for review, but should not be merged until corresponding changes are made in the client.