### PR TITLE
Bucket prefix

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -20,7 +20,7 @@ def get_asset_blob_storage() -> Storage:
 
 
 def get_asset_blob_prefix(instance: AssetBlob, filename: str) -> str:
-    return filename
+    return f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}{filename}'
 
 
 class AssetBlob(TimeStampedModel):

--- a/dandiapi/api/models/upload.py
+++ b/dandiapi/api/models/upload.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+from django.conf import settings
 from django.core.validators import RegexValidator
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
@@ -47,7 +48,10 @@ class Upload(TimeStampedModel):
     @classmethod
     def object_key(cls, upload_id):
         upload_id = str(upload_id)
-        return f'dev/blobs/{upload_id[0:3]}/{upload_id[3:6]}/{upload_id}'
+        return (
+            f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}'
+            f'blobs/{upload_id[0:3]}/{upload_id[3:6]}/{upload_id}'
+        )
 
     @classmethod
     def initialize_multipart_upload(cls, etag, size):

--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -1,5 +1,6 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db.transaction import atomic
 from rest_framework_yaml.renderers import YAMLRenderer
@@ -37,7 +38,8 @@ def write_yamls(version_id: int) -> None:
     storage = AssetBlob.blob.field.storage
 
     dandiset_yaml_path = (
-        f'dev/dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
+        f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}'
+        f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
     )
     if storage.exists(dandiset_yaml_path):
         logger.info('%s already exists, deleting it', dandiset_yaml_path)
@@ -46,7 +48,10 @@ def write_yamls(version_id: int) -> None:
     dandiset_yaml = YAMLRenderer().render(version.metadata.metadata)
     storage.save(dandiset_yaml_path, ContentFile(dandiset_yaml))
 
-    assets_yaml_path = f'dev/dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    assets_yaml_path = (
+        f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}'
+        f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    )
     if storage.exists(assets_yaml_path):
         logger.info('%s already exists, deleting it', assets_yaml_path)
         storage.delete(assets_yaml_path)

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -35,9 +35,7 @@ def test_write_dandiset_yaml(storage: Storage, version: Version):
 
     tasks.write_yamls(version.id)
 
-    dandiset_yaml_path = (
-        f'dev/dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
-    )
+    dandiset_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
     # TODO this will fail if the test is run twice in the same minute.
     # The same version ID will be generated in the second test,
     # but the dandiset.yaml will still be present from the first test, creating a mismatch.
@@ -57,7 +55,7 @@ def test_write_assets_yaml(storage: Storage, version: Version, asset_factory):
 
     tasks.write_yamls(version.id)
 
-    assets_yaml_path = f'dev/dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    assets_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
     with storage.open(assets_yaml_path) as f:
         assert f.read() == YAMLRenderer().render(
             [asset.metadata.metadata for asset in version.assets.all()]
@@ -71,9 +69,7 @@ def test_write_dandiset_yaml_already_exists(storage: Storage, version: Version):
     AssetBlob.blob.field.storage = storage
 
     # Save an invalid file for the task to overwrite
-    dandiset_yaml_path = (
-        f'dev/dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
-    )
+    dandiset_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
     storage.save(dandiset_yaml_path, ContentFile(b'wrong contents'))
 
     tasks.write_yamls(version.id)
@@ -92,7 +88,7 @@ def test_write_assets_yaml_already_exists(storage: Storage, version: Version, as
     version.assets.add(asset_factory())
 
     # Save an invalid file for the task to overwrite
-    assets_yaml_path = f'dev/dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    assets_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
     storage.save(assets_yaml_path, ContentFile(b'wrong contents'))
 
     tasks.write_yamls(version.id)

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -1,5 +1,6 @@
 import hashlib
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 import pytest
@@ -35,7 +36,10 @@ def test_write_dandiset_yaml(storage: Storage, version: Version):
 
     tasks.write_yamls(version.id)
 
-    dandiset_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
+    dandiset_yaml_path = (
+        f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}'
+        f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
+    )
     # TODO this will fail if the test is run twice in the same minute.
     # The same version ID will be generated in the second test,
     # but the dandiset.yaml will still be present from the first test, creating a mismatch.
@@ -55,7 +59,10 @@ def test_write_assets_yaml(storage: Storage, version: Version, asset_factory):
 
     tasks.write_yamls(version.id)
 
-    assets_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    assets_yaml_path = (
+        f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}'
+        f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    )
     with storage.open(assets_yaml_path) as f:
         assert f.read() == YAMLRenderer().render(
             [asset.metadata.metadata for asset in version.assets.all()]
@@ -69,7 +76,10 @@ def test_write_dandiset_yaml_already_exists(storage: Storage, version: Version):
     AssetBlob.blob.field.storage = storage
 
     # Save an invalid file for the task to overwrite
-    dandiset_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
+    dandiset_yaml_path = (
+        f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}'
+        f'dandisets/{version.dandiset.identifier}/{version.version}/dandiset.yaml'
+    )
     storage.save(dandiset_yaml_path, ContentFile(b'wrong contents'))
 
     tasks.write_yamls(version.id)
@@ -88,7 +98,10 @@ def test_write_assets_yaml_already_exists(storage: Storage, version: Version, as
     version.assets.add(asset_factory())
 
     # Save an invalid file for the task to overwrite
-    assets_yaml_path = f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    assets_yaml_path = (
+        f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}'
+        f'dandisets/{version.dandiset.identifier}/{version.version}/assets.yaml'
+    )
     storage.save(assets_yaml_path, ContentFile(b'wrong contents'))
 
     tasks.write_yamls(version.id)

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -69,6 +69,7 @@ class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
     MINIO_STORAGE_MEDIA_URL = 'http://localhost:9000/test-django-storage'
 
     DANDI_DANDISETS_BUCKET_NAME = 'test-dandiapi-dandisets'
+    DANDI_DANDISETS_BUCKET_PREFIX = 'test-prefix/'
     DANDI_GIRDER_API_KEY = 'testkey'
     DANDI_GIRDER_API_URL = 'http://girder.test/api/v1'
 

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -46,6 +46,7 @@ class DandiMixin(ConfigMixin):
         ] = 'dandiapi.api.views.common.DandiPagination'
 
     DANDI_DANDISETS_BUCKET_NAME = values.Value(environ_required=True)
+    DANDI_DANDISETS_BUCKET_PREFIX = values.Value(default='', environ=True)
     DANDI_GIRDER_API_URL = values.URLValue(environ_required=True)
     DANDI_GIRDER_API_KEY = values.Value(environ_required=True)
     DANDI_SCHEMA_VERSION = values.Value(environ_required=True)


### PR DESCRIPTION
Rather than remove the `"dev/"` from all the bucket paths, I opted to replace it with a new setting, `DANDI_DANDISETS_BUCKET_PREFIX`. This moves where the files are stored from code to configuration, so we won't need any more PRs like this one to switch it on/off.

Fixes #214 