### PR TITLE
ENH: run dandi-cli tests for "push"es only to master

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -2,6 +2,8 @@ name: Test Integration with dandi-cli
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
So we do not have both "push" and "pull_request" builds appearing in PRs whenever there is a nice feature branch for the PR