### PR TITLE
Immutable published version

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -84,7 +84,8 @@ def test_asset_create(api_client, user, draft_version, asset_blob):
     metadata = {'path': path, 'meta': 'data', 'foo': ['bar', 'baz'], '1': 2}
 
     assert api_client.post(
-        f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/assets/',
+        f'/api/dandisets/{draft_version.dandiset.identifier}'
+        f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': asset_blob.blob_id},
         format='json',
     ).data == {
@@ -109,7 +110,8 @@ def test_asset_create_no_valid_blob(api_client, user, draft_version):
     uuid = uuid4()
 
     resp = api_client.post(
-        f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/assets/',
+        f'/api/dandisets/{draft_version.dandiset.identifier}'
+        f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': uuid},
         format='json',
     )
@@ -124,7 +126,8 @@ def test_asset_create_no_path(api_client, user, draft_version, asset_blob):
     metadata = {'meta': 'data', 'foo': ['bar', 'baz'], '1': 2}
 
     resp = api_client.post(
-        f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/assets/',
+        f'/api/dandisets/{draft_version.dandiset.identifier}'
+        f'/versions/{draft_version.version}/assets/',
         {'metadata': metadata, 'blob_id': asset_blob.blob_id},
         format='json',
     )
@@ -153,7 +156,8 @@ def test_asset_create_duplicate(api_client, user, draft_version, asset):
     draft_version.assets.add(asset)
 
     resp = api_client.post(
-        f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/assets/',
+        f'/api/dandisets/{draft_version.dandiset.identifier}'
+        f'/versions/{draft_version.version}/assets/',
         {
             'metadata': asset.metadata.metadata,
             'blob_id': asset.blob.blob_id,
@@ -171,7 +175,8 @@ def test_asset_create_published_version(api_client, user, published_version, ass
     published_version.assets.add(asset)
 
     resp = api_client.post(
-        f'/api/dandisets/{published_version.dandiset.identifier}/versions/{published_version.version}/assets/',
+        f'/api/dandisets/{published_version.dandiset.identifier}'
+        f'/versions/{published_version.version}/assets/',
         {
             'metadata': asset.metadata.metadata,
             'blob_id': asset.blob.blob_id,

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -291,18 +291,18 @@ def test_asset_rest_update_published_version(api_client, user, published_version
 
 
 @pytest.mark.django_db
-def test_asset_rest_delete(api_client, user, version, asset):
+def test_asset_rest_delete(api_client, user, draft_version, asset):
     api_client.force_authenticate(user=user)
-    assign_perm('owner', user, version.dandiset)
-    version.assets.add(asset)
+    assign_perm('owner', user, draft_version.dandiset)
+    draft_version.assets.add(asset)
 
     response = api_client.delete(
-        f'/api/dandisets/{version.dandiset.identifier}/'
-        f'versions/{version.version}/assets/{asset.asset_id}/'
+        f'/api/dandisets/{draft_version.dandiset.identifier}/'
+        f'versions/{draft_version.version}/assets/{asset.asset_id}/'
     )
     assert response.status_code == 204
 
-    assert asset not in version.assets.all()
+    assert asset not in draft_version.assets.all()
     assert asset in Asset.objects.all()
 
 
@@ -318,6 +318,20 @@ def test_asset_rest_delete_not_an_owner(api_client, user, version, asset):
     assert response.status_code == 403
 
     assert asset in Asset.objects.all()
+
+
+@pytest.mark.django_db
+def test_asset_rest_delete_published_version(api_client, user, published_version, asset):
+    api_client.force_authenticate(user=user)
+    assign_perm('owner', user, published_version.dandiset)
+    published_version.assets.add(asset)
+
+    response = api_client.delete(
+        f'/api/dandisets/{published_version.dandiset.identifier}/'
+        f'versions/{published_version.version}/assets/{asset.asset_id}/'
+    )
+    assert response.status_code == 405
+    assert response.data == 'Only draft versions can be modified.'
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -178,14 +178,10 @@ def test_version_rest_update_published_version(api_client, user, published_versi
 
     new_name = 'A unique and special name!'
     new_metadata = {'foo': 'bar', 'num': 123, 'list': ['a', 'b', 'c']}
-    saved_metadata = {
-        **new_metadata,
-        'name': new_name,
-        'identifier': f'DANDI:{published_version.dandiset.identifier}',
-    }
 
     resp = api_client.put(
-        f'/api/dandisets/{published_version.dandiset.identifier}/versions/{published_version.version}/',
+        f'/api/dandisets/{published_version.dandiset.identifier}'
+        f'/versions/{published_version.version}/',
         {'metadata': new_metadata, 'name': new_name},
         format='json',
     )

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -93,8 +93,8 @@ def test_version_rest_retrieve_with_asset(api_client, version, asset):
 
 
 @pytest.mark.django_db
-def test_version_rest_update(api_client, user, version):
-    assign_perm('owner', user, version.dandiset)
+def test_version_rest_update(api_client, user, draft_version):
+    assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
 
     new_name = 'A unique and special name!'
@@ -102,36 +102,36 @@ def test_version_rest_update(api_client, user, version):
     saved_metadata = {
         **new_metadata,
         'name': new_name,
-        'identifier': f'DANDI:{version.dandiset.identifier}',
+        'identifier': f'DANDI:{draft_version.dandiset.identifier}',
     }
 
     assert api_client.put(
-        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/',
+        f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
         {'metadata': new_metadata, 'name': new_name},
         format='json',
     ).data == {
         'dandiset': {
-            'identifier': version.dandiset.identifier,
+            'identifier': draft_version.dandiset.identifier,
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
         },
-        'version': version.version,
+        'version': draft_version.version,
         'name': new_name,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
-        'asset_count': version.asset_count,
+        'asset_count': draft_version.asset_count,
         'metadata': saved_metadata,
-        'size': version.size,
+        'size': draft_version.size,
     }
 
-    version.refresh_from_db()
-    assert version.metadata.metadata == saved_metadata
-    assert version.metadata.name == new_name
+    draft_version.refresh_from_db()
+    assert draft_version.metadata.metadata == saved_metadata
+    assert draft_version.metadata.name == new_name
 
 
 @pytest.mark.django_db
-def test_version_rest_update_large(api_client, user, version):
-    assign_perm('owner', user, version.dandiset)
+def test_version_rest_update_large(api_client, user, draft_version):
+    assign_perm('owner', user, draft_version.dandiset)
     api_client.force_authenticate(user=user)
 
     new_name = 'A unique and special name!'
@@ -144,31 +144,53 @@ def test_version_rest_update_large(api_client, user, version):
     saved_metadata = {
         **new_metadata,
         'name': new_name,
-        'identifier': f'DANDI:{version.dandiset.identifier}',
+        'identifier': f'DANDI:{draft_version.dandiset.identifier}',
     }
 
     assert api_client.put(
-        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/',
+        f'/api/dandisets/{draft_version.dandiset.identifier}/versions/{draft_version.version}/',
         {'metadata': new_metadata, 'name': new_name},
         format='json',
     ).data == {
         'dandiset': {
-            'identifier': version.dandiset.identifier,
+            'identifier': draft_version.dandiset.identifier,
             'created': TIMESTAMP_RE,
             'modified': TIMESTAMP_RE,
         },
-        'version': version.version,
+        'version': draft_version.version,
         'name': new_name,
         'created': TIMESTAMP_RE,
         'modified': TIMESTAMP_RE,
-        'asset_count': version.asset_count,
+        'asset_count': draft_version.asset_count,
         'metadata': saved_metadata,
-        'size': version.size,
+        'size': draft_version.size,
     }
 
-    version.refresh_from_db()
-    assert version.metadata.metadata == saved_metadata
-    assert version.metadata.name == new_name
+    draft_version.refresh_from_db()
+    assert draft_version.metadata.metadata == saved_metadata
+    assert draft_version.metadata.name == new_name
+
+
+@pytest.mark.django_db
+def test_version_rest_update_published_version(api_client, user, published_version):
+    assign_perm('owner', user, published_version.dandiset)
+    api_client.force_authenticate(user=user)
+
+    new_name = 'A unique and special name!'
+    new_metadata = {'foo': 'bar', 'num': 123, 'list': ['a', 'b', 'c']}
+    saved_metadata = {
+        **new_metadata,
+        'name': new_name,
+        'identifier': f'DANDI:{published_version.dandiset.identifier}',
+    }
+
+    resp = api_client.put(
+        f'/api/dandisets/{published_version.dandiset.identifier}/versions/{published_version.version}/',
+        {'metadata': new_metadata, 'name': new_name},
+        format='json',
+    )
+    assert resp.status_code == 405
+    assert resp.data == 'Only draft versions can be modified.'
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -193,6 +193,11 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         version = Version.objects.get(
             dandiset__pk=versions__dandiset__pk, version=versions__version
         )
+        if version.version != 'draft':
+            return Response(
+                'Only draft versions can be modified.',
+                status=status.HTTP_405_METHOD_NOT_ALLOWED,
+            )
 
         version.assets.remove(asset)
         return Response(None, status=status.HTTP_204_NO_CONTENT)

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -99,6 +99,11 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
             dandiset=versions__dandiset__pk,
             version=versions__version,
         )
+        if version.version != 'draft':
+            return Response(
+                'Only draft versions can be modified.',
+                status=status.HTTP_405_METHOD_NOT_ALLOWED,
+            )
 
         serializer = AssetRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -146,6 +146,11 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
             dandiset__pk=versions__dandiset__pk,
             version=versions__version,
         )
+        if version.version != 'draft':
+            return Response(
+                'Only draft versions can be modified.',
+                status=status.HTTP_405_METHOD_NOT_ALLOWED,
+            )
 
         serializer = AssetRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -39,6 +39,11 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     def update(self, request, **kwargs):
         """Update the metadata of a version."""
         version: Version = self.get_object()
+        if version.version != 'draft':
+            return Response(
+                'Only draft versions can be modified.',
+                status=status.HTTP_405_METHOD_NOT_ALLOWED,
+            )
 
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
Make it so that published versions cannot be modified through the API. This means no version metadata changes and no asset creation, update, or delete.