### PR TITLE
Use social account info for API endpoints

### DIFF
--- a/dandiapi/api/tests/conftest.py
+++ b/dandiapi/api/tests/conftest.py
@@ -17,6 +17,7 @@ from .factories import (
     DandisetFactory,
     DraftVersionFactory,
     PublishedVersionFactory,
+    SocialAccountFactory,
     UploadFactory,
     UserFactory,
     VersionMetadataFactory,
@@ -36,6 +37,7 @@ register(DraftVersionFactory, _name='draft_version')
 # registering DraftVersionFactory after PublishedVersionFactory means
 # the fixture `version` will always be a draft
 register(UserFactory)
+register(SocialAccountFactory)
 register(UploadFactory)
 register(VersionMetadataFactory)
 

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -1,7 +1,9 @@
 import hashlib
 
+from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
 import factory
+import faker
 
 from dandiapi.api.models import (
     Asset,
@@ -22,6 +24,25 @@ class UserFactory(factory.django.DjangoModelFactory):
     email = factory.Faker('safe_email')
     first_name = factory.Faker('first_name')
     last_name = factory.Faker('last_name')
+
+
+class SocialAccountFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = SocialAccount
+
+    user = factory.SubFactory(UserFactory)
+    uid = factory.Faker('sha1')
+
+    @factory.lazy_attribute
+    def extra_data(self):
+        first_name = faker.Faker().first_name()
+        last_name = faker.Faker().last_name()
+        name = f'{first_name} {last_name}'
+        return {
+            'login': first_name,
+            'name': name,
+            'email': self.user.username,
+        }
 
 
 class DandisetFactory(factory.django.DjangoModelFactory):

--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -104,25 +104,7 @@ def test_user_search_multiple_matches(api_client, user, user_factory):
             {'username': 'jane'},
             format='json',
         ).data
-        == [serialize(user) for user in users[:3]]
-    )
-
-
-@pytest.mark.django_db
-def test_user_search_alphabetical(api_client, user, user_factory):
-    api_client.force_authenticate(user=user)
-
-    # Create the users in reverse alphabetical order
-    user_z = user_factory(username='jane_z')
-    user_a = user_factory(username='jane_a')
-
-    assert (
-        api_client.get(
-            '/api/users/search/?',
-            {'username': 'jane'},
-            format='json',
-        ).data
-        == [serialize(user_a), serialize(user_z)]
+        == [serialize_social_account(social_account) for social_account in social_accounts[:3]]
     )
 
 

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -11,8 +11,7 @@ class UserSerializer(serializers.Serializer):
 
 class UserDetailSerializer(serializers.Serializer):
     username = serializers.CharField(validators=[UnicodeUsernameValidator()])
-    first_name = serializers.CharField(validators=[UnicodeUsernameValidator()])
-    last_name = serializers.CharField(validators=[UnicodeUsernameValidator()])
+    name = serializers.CharField(validators=[UnicodeUsernameValidator()])
     admin = serializers.BooleanField()
 
 

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
-from django.forms.models import model_to_dict
 from django.http.response import HttpResponseBase
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view, parser_classes, permission_classes
@@ -13,6 +13,36 @@ from rest_framework.response import Response
 from dandiapi.api.views.serializers import UserDetailSerializer, UserSerializer
 
 
+def user_to_dict(user: User):
+    """
+    Serialize a user to a dict.
+
+    This exists only as a fallback in case a user doesn't have a social account.
+    """
+    return {
+        'admin': user.is_superuser,
+        'username': user.username,
+        'name': f'{user.first_name} {user.last_name}'.strip(),
+    }
+
+
+def social_account_to_dict(social_account: SocialAccount):
+    """Serialize a social account to a dict."""
+    user = social_account.user
+    # This is a reasonable default if the attached GitHub account doesn't have a name
+    name = f'{user.first_name} {user.last_name}'.strip()
+
+    # We are assuming that login is a required field for GitHub users
+    username = social_account.extra_data['login']
+    name = social_account.extra_data.get('name') or name
+
+    return {
+        'admin': user.is_superuser,
+        'username': username,
+        'name': name,
+    }
+
+
 @swagger_auto_schema(
     method='GET',
     responses={200: UserDetailSerializer},
@@ -22,8 +52,11 @@ from dandiapi.api.views.serializers import UserDetailSerializer, UserSerializer
 @permission_classes([IsAuthenticated])
 def users_me_view(request: Request) -> HttpResponseBase:
     """Get the currently authenticated user."""
-    user_dict = {'admin': request.user.is_superuser, **model_to_dict(request.user)}
-
+    if request.user.socialaccount_set.count() == 1:
+        social_account = request.user.socialaccount_set.get()
+        user_dict = social_account_to_dict(social_account)
+    else:
+        user_dict = user_to_dict(request.user)
     response_serializer = UserDetailSerializer(user_dict)
     return Response(response_serializer.data)
 
@@ -42,8 +75,8 @@ def users_search_view(request: Request) -> HttpResponseBase:
     request_serializer.is_valid(raise_exception=True)
     username: str = request_serializer.validated_data['username']
 
-    results = User.objects.filter(username__startswith=username).order_by('username')[:10]
-    dict_results = [{'admin': user.is_superuser, **model_to_dict(user)} for user in results]
+    social_accounts = SocialAccount.objects.filter(extra_data__icontains=username)[:10]
+    users = [social_account_to_dict(social_account) for social_account in social_accounts]
 
-    response_serializer = UserDetailSerializer(dict_results, many=True)
+    response_serializer = UserDetailSerializer(users, many=True)
     return Response(response_serializer.data)


### PR DESCRIPTION
This should fix #226 

Currently we use only the information available in the generic Django `User` class to power the API. This means that we have been exposing user's emails for ownership display/management, which is bad.

This PR will use the `login` and `name` JSON fields from the `extra_data` field on the `SocialAccount` model in place of `username` (which is always the user's email) and `first_name`/`last_name`.

Along with dandi/dandiarchive#624, user's emails will no longer be exposed in the client. Only GitHub handles and names will be used.