### PR TITLE
Version metadata endpoint

### DIFF
--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -52,8 +52,18 @@ def test_version_rest_list(api_client, version):
 
 @pytest.mark.django_db
 def test_version_rest_retrieve(api_client, version):
+    assert (
+        api_client.get(
+            f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/'
+        ).data
+        == version.metadata.metadata
+    )
+
+
+@pytest.mark.django_db
+def test_version_rest_info(api_client, version):
     assert api_client.get(
-        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/'
+        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/info/'
     ).data == {
         'dandiset': {
             'identifier': version.dandiset.identifier,
@@ -71,11 +81,11 @@ def test_version_rest_retrieve(api_client, version):
 
 
 @pytest.mark.django_db
-def test_version_rest_retrieve_with_asset(api_client, version, asset):
+def test_version_rest_info_with_asset(api_client, version, asset):
     version.assets.add(asset)
 
     assert api_client.get(
-        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/'
+        f'/api/dandisets/{version.dandiset.identifier}/versions/{version.version}/info/'
     ).data == {
         'dandiset': {
             'identifier': version.dandiset.identifier,

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -40,6 +40,21 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
         version = self.get_object()
         return Response(version.metadata.metadata, status=status.HTTP_200_OK)
 
+    # TODO clean up this action
+    # Originally retrieve() returned this, but the API specification was modified so that
+    # retrieve() only returns the metadata for a version, instead of a serialization.
+    # Unfortunately the web UI is built around VersionDetailSerializer, so this endpoint was
+    # added to avoid rewriting the web UI.
+    @swagger_auto_schema(
+        responses={200: VersionDetailSerializer()},
+    )
+    @action(detail=True, methods=['GET'])
+    def info(self, request, **kwargs):
+        """Django serialization of a version."""
+        version = self.get_object()
+        serializer = VersionDetailSerializer(instance=version)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
     @swagger_auto_schema(
         request_body=VersionMetadataSerializer(),
         responses={200: VersionDetailSerializer()},

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -32,6 +32,15 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
     lookup_value_regex = Version.VERSION_REGEX
 
     @swagger_auto_schema(
+        responses={
+            200: 'The version metadata.',
+        },
+    )
+    def retrieve(self, request, **kwargs):
+        version = self.get_object()
+        return Response(version.metadata.metadata, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(
         request_body=VersionMetadataSerializer(),
         responses={200: VersionDetailSerializer()},
     )


### PR DESCRIPTION
The version detail endpoint
(/dandisets/{dandiset_id}/versions/{version_id}) has been changed to
only return the version metadata. To avoid changing everything in the
frontend to use the metadata schema, a new version action info was
added.

Requires dandi/dandiarchive#628 to keep the UI from breaking.

Requires dandi/dandi-cli#575 to keep the CLI from breaking. I believe a new CLI release will also fix the tests.