### PR TITLE
Extend girder client limit so all dandisets are updated

### DIFF
--- a/scripts/copy_dandiset_dates.py
+++ b/scripts/copy_dandiset_dates.py
@@ -19,7 +19,7 @@ from dandiapi.api.models import Dandiset, Version
 
 def get_girder_dandisets(gc):
     dandisets = {}
-    for dandiset in gc.get('/dandi'):
+    for dandiset in gc.get('/dandi?limit=200'):
         identifier = dandiset['meta']['dandiset']['identifier']
         dandisets[identifier] = (
             datetime.fromisoformat(dandiset['created']),


### PR DESCRIPTION
The default limit in the girder client is 50, which is less than the number of dandisets to update. Bump that limit to 200, which is significantly more than the number of dandisets. 