### PR TITLE
Update steps in dev/django.Dockerfile

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -9,10 +9,14 @@ RUN apt-get update && \
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# Only copy the setup.py, it will still force all install_requires to be installed,
+# Copy versioneer.py so it can be accessed by setup.py
+COPY ./versioneer.py /opt/django-project/versioneer.py
+
+# Only copy the setup.py and setup.cfg, it will still force all install_requires to be installed,
 # but find_packages() will find nothing (which is fine). When Docker Compose mounts the real source
 # over top of this directory, the .egg-link in site-packages resolves to the mounted directory
 # and all package modules are importable.
+COPY ./setup.cfg /opt/django-project/setup.cfg
 COPY ./setup.py /opt/django-project/setup.py
 RUN pip install --editable /opt/django-project[dev]
 


### PR DESCRIPTION
There were some missing steps in `dev/django.Dockerfile` which caused `docker-compose build` to fail, as it couldn't fine `versioneer.py` or `setup.cfg`.