### PR TITLE
ENH: add "extended" option to /paths endpoint

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Set
+from typing import Dict, List
 import uuid
 
 from django.conf import settings
@@ -125,7 +125,7 @@ class Asset(TimeStampedModel):
         return Asset(path=asset.path, blob=asset.blob, metadata=asset.metadata)
 
     @classmethod
-    def get_path(cls, path_prefix: str, qs: List[dict], extended: bool=False) -> List:
+    def get_path(cls, path_prefix: str, qs: List[dict], extended: bool = False) -> List:
         """
         Return the unique files/directories that directly reside under the specified path.
 
@@ -154,10 +154,10 @@ class Asset(TimeStampedModel):
                     # Initiate the record from the asset.  It will only miss
                     # asset_id field and otherwise be the same with cumulative information
                     paths[base_path] = {
-                        "path": f'{base_path}/',
-                        "size": asset['size'],
-                        "created": asset['created'],
-                        "modified": asset['modified'],
+                        'path': f'{base_path}/',
+                        'size': asset['size'],
+                        'created': asset['created'],
+                        'modified': asset['modified'],
                     }
                 else:
                     # update record

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -125,7 +125,7 @@ class Asset(TimeStampedModel):
         return Asset(path=asset.path, blob=asset.blob, metadata=asset.metadata)
 
     @classmethod
-    def get_path(cls, path_prefix: str, qs: List[dict], extended: bool) -> List:
+    def get_path(cls, path_prefix: str, qs: List[dict], extended: bool=False) -> List:
         """
         Return the unique files/directories that directly reside under the specified path.
 

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -252,7 +252,8 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
 
     @swagger_auto_schema(
         manual_parameters=[
-            openapi.Parameter('path_prefix', openapi.IN_QUERY, type=openapi.TYPE_STRING)
+            openapi.Parameter('path_prefix', openapi.IN_QUERY, type=openapi.TYPE_STRING),
+            openapi.Parameter('extended', openapi.IN_QUERY, type=openapi.TYPE_BOOLEAN)
         ],
         responses={
             200: openapi.Schema(
@@ -270,11 +271,12 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         (to refer to the root folder) must be the empty string.
         """
         path_prefix: str = self.request.query_params.get('path_prefix') or ''
+        extended: bool = self.request.query_params.get('extended') or False
         # Enforce trailing slash
         if path_prefix and path_prefix[-1] != '/':
             path_prefix = f'{path_prefix}/'
         qs = self.get_queryset().filter(path__startswith=path_prefix).values()
 
-        return Response(Asset.get_path(path_prefix, qs))
+        return Response(Asset.get_path(path_prefix, qs, extended=extended))
 
     # TODO: add create to forge an asset from a validation


### PR DESCRIPTION
ATM there is a growing number of issues which related to deficiencies  in
listing of assets, and some of which relate to parity with older girder-based
interface, e.g

- no sizes for assets (or directories) shown:
  https://github.com/dandi/dandiarchive/issues/644
  https://github.com/dandi/dandiarchive/issues/586

- getting a listing with download buttons takes way too long:
  https://github.com/dandi/dandiarchive/issues/638

/paths endpoint already loops through the list of available assets but returns
only deduced paths.  IMHO this would be the logical place to improve it to
(optionally) make returned list virtually at no processing cost, and not only
providing a solution to aforementioned issues but also adding possibility to
enhance "View data" interface with

- displaying sizes not only for assets but directories as well
  (even beating old girder-based implementation which IIRC was only
  displaying size of files immediately under the path)
- sorting by size, created, modified

If decided to proceed this way, TODOs to finalize:

- [ ] unit-test
- [?] better sorting for "extended" - should pair "asset_id" (or None
      for folders) and "path" so we get subfolders first and then assets. edit: although -- might better remove sorting altogether since ATM it doesn't care about sorting folders first (thus we UI probably does it anyways). If desired, a "sort" option could be introduced.


PS I have not tried it locally since failed to re-bootstrap development environment following README.
