### PR TITLE
Switch from social_account_added to user_signed_up

### DIFF
--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -1,5 +1,5 @@
-from allauth.socialaccount.models import SocialLogin
-from allauth.socialaccount.signals import social_account_added
+from allauth.account.signals import user_signed_up
+from django.contrib.auth.models import User
 import pytest
 
 
@@ -15,11 +15,9 @@ def serialize_social_account(social_account):
 def test_user_registration_email(social_account, mailoutbox):
     user = social_account.user
 
-    # The registration signal is only sent when the user registers through an API call.
+    # The sign up signal is only sent when the user registers through an API call.
     # This is hard to emulate, so we just send the signal manually.
-    # Wrap the social_account in a SocialLogin, as required
-    sociallogin = SocialLogin(user=user, account=social_account)
-    social_account_added.send(sender=SocialLogin, sociallogin=sociallogin)
+    user_signed_up.send(sender=User, user=user)
 
     assert len(mailoutbox) == 1
     assert mailoutbox[0].subject == f'DANDI: New user registered: {user.email}'


### PR DESCRIPTION
It turns out that django-allauth only sends the `social_account_added`
when a new social account is connected to an existing user, not when a
new SocialAccount + User are registered. Instead we need to use the
`user_signed_up` signal and look up all of the social accounts for the
new user.

The change list is intimidating, but most of it is changing arguments from a `sociallogin` which contained a user+socialaccount, to directly specifying `user` and `socialaccount`.