### PR TITLE
ENH: disallow non-super users creating dandisets with a specified identifier

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -222,8 +222,8 @@ def test_dandiset_rest_create(api_client, user):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_create_with_identifier(api_client, user):
-    api_client.force_authenticate(user=user)
+def test_dandiset_rest_create_with_identifier(api_client, admin_user):
+    api_client.force_authenticate(user=admin_user)
     name = 'Test Dandiset'
     identifier = '123456'
     metadata = {'foo': 'bar', 'identifier': f'DANDI:{identifier}'}
@@ -256,7 +256,7 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
     # Creating a Dandiset has side affects.
     # Verify that the user is the only owner.
     dandiset = Dandiset.objects.get(id=identifier)
-    assert list(dandiset.owners.all()) == [user]
+    assert list(dandiset.owners.all()) == [admin_user]
 
     # Verify that a draft Version and VersionMetadata were also created.
     assert dandiset.versions.count() == 1
@@ -279,8 +279,8 @@ def test_dandiset_rest_create_with_identifier(api_client, user):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_create_with_duplicate_identifier(api_client, user, dandiset):
-    api_client.force_authenticate(user=user)
+def test_dandiset_rest_create_with_duplicate_identifier(api_client, admin_user, dandiset):
+    api_client.force_authenticate(user=admin_user)
     name = 'Test Dandiset'
     identifier = dandiset.identifier
     metadata = {'foo': 'bar', 'identifier': f'DANDI:{identifier}'}
@@ -295,8 +295,8 @@ def test_dandiset_rest_create_with_duplicate_identifier(api_client, user, dandis
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_create_with_invalid_identifier(api_client, user):
-    api_client.force_authenticate(user=user)
+def test_dandiset_rest_create_with_invalid_identifier(api_client, admin_user):
+    api_client.force_authenticate(user=admin_user)
     name = 'Test Dandiset'
     identifier = 'abc123'
     metadata = {'foo': 'bar', 'identifier': identifier}

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -103,6 +103,12 @@ class DandisetViewSet(ReadOnlyModelViewSet):
 
         if 'identifier' in serializer.validated_data['metadata']:
             identifier = serializer.validated_data['metadata']['identifier']
+            if identifier and not request.user.is_superuser:
+                return Response(
+                    'Creating a dandiset for a given identifier '
+                    f'({identifier} was provided) is admin only operation.',
+                    status=403,
+                )
             if identifier.startswith('DANDI:'):
                 identifier = identifier[6:]
             try:


### PR DESCRIPTION
We have got dandiset 000105 leaping from 000070.  It seems that operation was initiated
from web-ui so in principle the issue is probably not related to this change.  But especially
now that migration is over, I think it would be wise to allow for creation of dandisets
with a given identifier to be allowed only to the superusers, so someone does not
create 999999 dandiset thus making us run of the "dandiset id namespace"

I am not quite sure if my use of `request.user.is_superuser` is kosher but I saw
```
dandiapi/api/views/version.py:        if not request.user.is_superuser:
```
so decided that it should be ok