### PR TITLE
Fix migrations

### DIFF
--- a/dandiapi/api/migrations/0008_version_validation_status.py
+++ b/dandiapi/api/migrations/0008_version_validation_status.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name='asset',
+            model_name='version',
             name='status',
             field=models.CharField(
                 choices=[
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.AddField(
-            model_name='asset',
+            model_name='version',
             name='validation_error',
             field=models.TextField(default=''),
         ),

--- a/dandiapi/api/migrations/0008_version_validation_status.py
+++ b/dandiapi/api/migrations/0008_version_validation_status.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('api', '0006_default_oauth_application'),
+        ('api', '0007_validation_status'),
     ]
 
     operations = [


### PR DESCRIPTION
I had added changes to migration 0007 in two different commits which
were deployed to staging at different times. Because the current code of
0007 contains some changes that were applied in staging and some that
weren't, it is impossible to apply or unapply that migration. The
solution is to break it apart into two different migrations.