### PR TITLE
Actually validate version metadata

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -19,6 +19,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from dandiapi.api.mail import send_ownership_change_emails
 from dandiapi.api.models import Dandiset, Version, VersionMetadata
+from dandiapi.api.tasks import validate_version_metadata
 from dandiapi.api.views.common import DandiPagination
 from dandiapi.api.views.serializers import (
     DandisetDetailSerializer,
@@ -143,6 +144,8 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         # Create new draft version
         version = Version(dandiset=dandiset, metadata=version_metadata, version='draft')
         version.save()
+
+        validate_version_metadata.delay(version.id)
 
         serializer = DandisetDetailSerializer(instance=dandiset)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -10,7 +10,7 @@ from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSe
 
 from dandiapi.api import doi
 from dandiapi.api.models import Dandiset, Version, VersionMetadata
-from dandiapi.api.tasks import write_yamls
+from dandiapi.api.tasks import validate_version_metadata, write_yamls
 from dandiapi.api.views.common import DandiPagination
 from dandiapi.api.views.serializers import (
     VersionDetailSerializer,
@@ -82,6 +82,8 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
         version.metadata = version_metadata
         version.save()
+
+        validate_version_metadata.delay(version.id)
 
         serializer = VersionDetailSerializer(instance=version)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
The validate_version_metadata task was all set up, but was not actually
triggered when version metadata was modified.