### PR TITLE
Publish metadata

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -170,10 +170,6 @@ class Asset(TimeStampedModel):
         return self.path
 
     @classmethod
-    def copy(cls, asset):
-        return Asset(path=asset.path, blob=asset.blob, metadata=asset.metadata)
-
-    @classmethod
     def get_path(cls, path_prefix: str, qs: List[str]) -> Set:
         """
         Return the unique files/directories that directly reside under the specified path.

--- a/dandiapi/api/models/metadata.py
+++ b/dandiapi/api/models/metadata.py
@@ -1,0 +1,24 @@
+import datetime
+from uuid import uuid4
+
+
+# TODO does AssetMetadata need this?
+class PublishableMetadataMixin:
+    def published_by(self, now: datetime.datetime):
+        return {
+            'id': uuid4().urn,
+            'name': 'DANDI publish',
+            'startDate': now.isoformat(),
+            # TODO endDate needs to be defined before publish is complete
+            'endDate': now.isoformat(),
+            'wasAssociatedWith': [
+                {
+                    'id': 'RRID:SCR_017571',
+                    'name': 'DANDI API',
+                    # TODO version the API
+                    'version': '0.1.0',
+                    'schemaKey': 'Software',
+                }
+            ],
+            'schemaKey': 'PublishActivity',
+        }

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -104,9 +104,35 @@ class Version(TimeStampedModel):
 
         return version
 
-    @classmethod
-    def copy(cls, version):
-        return Version(dandiset=version.dandiset, metadata=version.metadata)
+    @property
+    def publish_version(self):
+        """
+        Generate a published version + metadata without saving it.
+
+        This is useful to validate version metadata without saving it.
+        """
+        now = datetime.datetime.utcnow()
+        # Inject the publishedBy and datePublished fields
+        published_metadata, _ = VersionMetadata.objects.get_or_create(
+            name=self.metadata.name,
+            metadata={
+                **self.metadata.metadata,
+                'publishedBy': self.metadata.published_by(now),
+                'datePublished': now.isoformat(),
+            },
+        )
+
+        # Create the published model
+        published_version = Version(dandiset=self.dandiset, metadata=published_metadata)
+
+        # Recompute the metadata
+        published_metadata, _ = VersionMetadata.objects.get_or_create(
+            name=self.name,
+            metadata=published_version._populate_metadata(),
+        )
+        published_version.metadata = published_metadata
+
+        return published_version
 
     @classmethod
     def citation(cls, metadata):

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -163,6 +163,8 @@ class Version(TimeStampedModel):
             'url': f'https://dandiarchive.org/{self.dandiset.identifier}/{self.version}',
         }
         metadata['citation'] = self.citation(metadata)
+        if self.doi:
+            metadata['doi'] = self.doi
         if 'schemaVersion' in metadata:
             schema_version = metadata['schemaVersion']
             metadata['@context'] = (

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -143,8 +143,10 @@ class Version(TimeStampedModel):
                 'https://raw.githubusercontent.com/dandi/schema/master/releases/'
                 f'{schema_version}/context.json'
             )
+        return metadata
 
-        new: VersionMetadata
+    def save(self, *args, **kwargs):
+        metadata = self._populate_metadata()
         new, created = VersionMetadata.objects.get_or_create(
             name=self.metadata.name,
             metadata=metadata,
@@ -154,9 +156,6 @@ class Version(TimeStampedModel):
             new.save()
 
         self.metadata = new
-
-    def save(self, *args, **kwargs):
-        self._populate_metadata()
         super().save(*args, **kwargs)
 
     def __str__(self) -> str:

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -7,10 +7,12 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
 
+from dandiapi.api.models.metadata import PublishableMetadataMixin
+
 from .dandiset import Dandiset
 
 
-class VersionMetadata(TimeStampedModel):
+class VersionMetadata(PublishableMetadataMixin, TimeStampedModel):
     metadata = models.JSONField(default=dict)
     name = models.CharField(max_length=300)
 

--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -157,7 +157,8 @@ def validate_version_metadata(version_id: int) -> None:
     version.save()
 
     try:
-        metadata = version.metadata.metadata
+        publish_version = version.publish_version
+        metadata = publish_version.metadata.metadata
         if 'schemaVersion' not in metadata:
             logger.info('schemaVersion not specified in metadata for version %s', version_id)
             raise ValidationError('schemaVersion not specified')

--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -151,7 +151,7 @@ def validate_asset_metadata(version_id: int, asset_id: int) -> None:
 @atomic
 def validate_version_metadata(version_id: int) -> None:
     logger.info('Validating dandiset metadata for version %s', version_id)
-    version = Version.objects.get(id=version_id)
+    version: Version = Version.objects.get(id=version_id)
 
     version.status = Version.Status.VALIDATING
     version.save()

--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -159,6 +159,10 @@ def validate_version_metadata(version_id: int) -> None:
     try:
         publish_version = version.publish_version
         metadata = publish_version.metadata.metadata
+
+        # Inject a dummy DOI so the metadata is valid
+        metadata['doi'] = '10.abc123'
+
         if 'schemaVersion' not in metadata:
             logger.info('schemaVersion not specified in metadata for version %s', version_id)
             raise ValidationError('schemaVersion not specified')

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -65,23 +65,7 @@ class VersionMetadataFactory(factory.django.DjangoModelFactory):
             'description': f'description {random.random()}',
             'contributor': [{}],
             'license': ['spdx:CC0-1.0'],
-            'doi': '10.abc123',
-            'publishedBy': {
-                'id': uuid4().urn,
-                'name': 'DANDI publish',
-                'startDate': '2021-05-18T19:58:39.310338-04:00',
-                'endDate': '2021-05-18T19:58:39.310361-04:00',
-                'wasAssociatedWith': [
-                    {
-                        'id': 'RRID:SCR_017571',
-                        'name': 'DANDI API',
-                        'version': '0.1.0',
-                        'schemaKey': 'Software',
-                    }
-                ],
-                'schemaKey': 'PublishActivity',
-            },
-            'datePublished': str(datetime.datetime.now()),
+            # TODO auto-populate assetsSummary
             'assetsSummary': {
                 'numberOfBytes': 1,
                 'numberOfFiles': 1,

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from django.contrib.auth.models import User
 from guardian.shortcuts import assign_perm
 import pytest
 
@@ -367,7 +368,7 @@ def test_version_rest_update_not_an_owner(api_client, user, version):
 
 @pytest.mark.django_db
 # TODO change admin_user back to a normal user once publish is allowed
-def test_version_rest_publish(api_client, admin_user, draft_version, asset):
+def test_version_rest_publish(api_client, admin_user: User, draft_version: Version, asset: Asset):
     assign_perm('owner', admin_user, draft_version.dandiset)
     api_client.force_authenticate(user=admin_user)
     draft_version.assets.add(asset)

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -375,6 +375,8 @@ def test_version_rest_publish(api_client, admin_user, draft_version, asset):
     # Validate the metadata to mark the version and asset as `VALID`
     tasks.validate_version_metadata(draft_version.id)
     tasks.validate_asset_metadata(draft_version.id, asset.id)
+    draft_version.refresh_from_db()
+    assert draft_version.valid
 
     resp = api_client.post(
         f'/api/dandisets/{draft_version.dandiset.identifier}'

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -109,7 +109,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        new_version = Version.copy(old_version)
+        new_version = old_version.publish_version
 
         new_version.doi = doi.create_doi(new_version)
 

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -96,7 +96,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
         if not request.user.is_superuser:
             return Response('Must be an admin to publish', status=status.HTTP_403_FORBIDDEN)
 
-        old_version = self.get_object()
+        old_version: Version = self.get_object()
         if old_version.version != 'draft':
             return Response(
                 'Only draft versions can be published',


### PR DESCRIPTION
A minor overhauling of how metadata is preprocessed before validation and publishing. `publishedBy`, `datePublished`, and `doi` all need to be injected into the version metadata before it is validated or published.

I added a mixin `PublishableMetadataMixin` that I had planned to add to both `VersionMetadata` and `AssetMetadata` that would generate the `publishedBy` field. It's possible that we don't actually need it for `AssetMetadata`, in which case I will rip it out and move it to `VersionMetadata` exclusively.