### PR TITLE
Do not report orphaned assets in size stats

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -147,4 +147,6 @@ class Asset(TimeStampedModel):
 
     @classmethod
     def total_size(cls):
-        return cls.objects.aggregate(size=models.Sum('blob__size'))['size'] or 0
+        return (
+            cls.objects.filter(versions__gt=0).aggregate(size=models.Sum('blob__size'))['size'] or 0
+        )

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -148,5 +148,8 @@ class Asset(TimeStampedModel):
     @classmethod
     def total_size(cls):
         return (
-            cls.objects.filter(versions__gt=0).aggregate(size=models.Sum('blob__size'))['size'] or 0
+            AssetBlob.objects.filter(assets__versions__isnull=False)
+            .distinct()
+            .aggregate(size=models.Sum('size'))['size']
+            or 0
         )

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -32,6 +32,17 @@ def test_asset_get_path(path, qs, expected):
     assert expected == Asset.get_path(path, qs)
 
 
+@pytest.mark.django_db
+def test_asset_total_size(version, asset_factory):
+    asset = asset_factory()
+    version.assets.add(asset)
+
+    orphaned_asset = asset_factory()
+
+    assert Asset.total_size() == asset.blob.size
+    assert Asset.total_size() < asset.blob.size + orphaned_asset.blob.size
+
+
 # API Tests
 
 

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -33,14 +33,24 @@ def test_asset_get_path(path, qs, expected):
 
 
 @pytest.mark.django_db
-def test_asset_total_size(version, asset_factory):
-    asset = asset_factory()
-    version.assets.add(asset)
+def test_asset_total_size(draft_version_factory, asset_factory, asset_blob_factory):
+    # This asset blob should only be counted once,
+    # despite belonging to multiple assets and multiple versions.
+    asset_blob = asset_blob_factory()
 
-    orphaned_asset = asset_factory()
+    asset1 = asset_factory(blob=asset_blob)
+    version1 = draft_version_factory()
+    version1.assets.add(asset1)
 
-    assert Asset.total_size() == asset.blob.size
-    assert Asset.total_size() < asset.blob.size + orphaned_asset.blob.size
+    asset2 = asset_factory(blob=asset_blob)
+    version2 = draft_version_factory()
+    version2.assets.add(asset2)
+
+    # These asset blobs should not be counted since they aren't in any versions.
+    asset_blob_factory()
+    asset_factory()
+
+    assert Asset.total_size() == asset_blob.size
 
 
 # API Tests

--- a/dandiapi/api/tests/test_stats.py
+++ b/dandiapi/api/tests/test_stats.py
@@ -38,7 +38,8 @@ def test_stats_user(api_client, user):
 
 
 @pytest.mark.django_db
-def test_stats_asset(api_client, asset):
+def test_stats_asset(api_client, version, asset):
+    version.assets.add(asset)
     stats = api_client.get('/api/stats/').data
 
     assert stats['size'] == asset.size


### PR DESCRIPTION
Filter out any assets that do not belong to a version when collecting
total size statistics.