### PR TITLE
BF: swap method call names for announcement email renditions

### DIFF
--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -101,9 +101,12 @@ def registered_message(user, socialaccount):
 
 Welcome to DANDI.
 
-You are now registered on the DANDI archive. Registering allows you to create Dandisets and upload data right away. You can also use the Jupyterhub (https://hub.dandiarchive.org) for computing on dandisets in the cloud.
+You are now registered on the DANDI archive. Registering allows you to create Dandisets and upload
+data right away. You can also use the Jupyterhub (https://hub.dandiarchive.org) for computing on
+dandisets in the cloud.
 
-It may take up to 24 hours for your hub account to be activated and for your email to be registered with our Slack workspace.
+It may take up to 24 hours for your hub account to be activated and for your email to be registered
+with our Slack workspace.
 
 Please use the following links to post any questions or issues.
 

--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -83,7 +83,7 @@ def registered_subject(user):
     return f'DANDI: New user registered: {user.email}'
 
 
-def registered_message(user, socialaccount):
+def registered_html_message(user, socialaccount):
     name = socialaccount.extra_data['name'] if 'name' in socialaccount.extra_data else user.username
     return f"""<p>Dear {name} (Github ID: {socialaccount.extra_data['login']}),</p>
 <p>Welcome to DANDI. </p>
@@ -95,7 +95,7 @@ def registered_message(user, socialaccount):
 <p>The DANDI team</p>"""  # noqa: E501
 
 
-def registered_html_message(user, socialaccount):
+def registered_message(user, socialaccount):
     name = socialaccount.extra_data['name'] if 'name' in socialaccount.extra_data else user.username
     return f"""Dear {name} (Github ID: {socialaccount.extra_data["login"]}),
 

--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -20,19 +20,12 @@ def test_user_registration_email(social_account, mailoutbox):
     user_signed_up.send(sender=User, user=user)
 
     assert len(mailoutbox) == 1
-    assert mailoutbox[0].subject == f'DANDI: New user registered: {user.email}'
-    assert mailoutbox[0].to == ['dandi@mit.edu', user.email]
-    assert (
-        mailoutbox[0].body
-        == f"""<p>Dear {social_account.extra_data['name']} (Github ID: {social_account.extra_data['login']}),</p>
-<p>Welcome to DANDI. </p>
-<p>You are now registered on the DANDI archive. Registering allows you to create Dandisets and upload data right away. You can also use the Jupyterhub (<a href="https://hub.dandiarchive.org">https://hub.dandiarchive.org</a>) for computing on dandisets in the cloud. </p>
-<p>It may take up to 24 hours for your hub account to be activated and for your email to be registered with our Slack workspace.</p>
-<p>Please post any <a href="https://github.com/dandi/helpdesk/discussions">questions</a> or <a href="https://github.com/dandi/helpdesk/issues">issues</a> at our <a href="https://github.com/dandi/helpdesk">Github helpdesk</a>.</p>
-<p>Thank you for choosing DANDI for your neurophysiology data needs.</p>
-<p>Sincerely,</p>
-<p>The DANDI team</p>"""  # noqa: E501
-    )
+
+    email = mailoutbox[0]
+    assert email.subject == f'DANDI: New user registered: {user.email}'
+    assert email.to == ['dandi@mit.edu', user.email]
+    assert '<p>' not in email.body
+    assert all(len(_) < 100 for _ in email.body.splitlines())
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
ATM html is sent as text, and text as html

Just received an email which looked odd after html was processed by lynx for my glorious emacs.
Looked into the code and then confirmed in the email that indeed swapped.

Filed https://github.com/dandi/dandi-api/issues/314 as a supplement

edit 1:

since needed a fix in the test, PR became a little more than just a bugfix and introduced my opinionated changes to the email text body formatting and the test.  Do not hesitate to suggest improvements etc.