### PR TITLE
Add `--no-threading` to the Dockerfile

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: ./dev/django.Dockerfile
-    command: ["./manage.py", "runserver", "0.0.0.0:8000"]
+    command: ["./manage.py", "runserver", "--nothreading", "0.0.0.0:8000"]
     # Log printing via Rich is enhanced by a TTY
     tty: true
     env_file: ./dev/.env.docker-compose


### PR DESCRIPTION
Sometimes the database drops connections after a while, and this is the StackOverflow-sourced solution.

@brianhelba, can you advise to the downsides of doing it this way? Also, should we upstream this change to the Girder 4 cookiecutter?