### PR TITLE
Add additional sorting options for dandisets

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -49,7 +49,8 @@ class DandisetFilterBackend(filters.OrderingFilter):
                 queryset = queryset.annotate(name=Subquery(latest_version.values('metadata__name')))
                 return queryset.order_by(ordering)
             elif ordering.endswith('modified'):
-                # name refers to the name of the most recent version, so a subquery is required
+                # modified refers to the modification timestamp of the most
+                # recent version, so a subquery is required
                 latest_version = Version.objects.filter(dandiset=OuterRef('pk')).order_by(
                     '-created'
                 )[:1]

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -53,12 +53,11 @@ class DandisetFilterBackend(filters.OrderingFilter):
                 latest_version = Version.objects.filter(dandiset=OuterRef('pk')).order_by(
                     '-created'
                 )[:1]
-                # Get the `modified` field of the latest Version's associated VersionMetadata.
-                # Append '_meta' to the field since there's already a 'modified' field on Dandisets
+                # get the `modified` field of the most recent version
                 queryset = queryset.annotate(
-                    modified_meta=Subquery(latest_version.values('metadata__modified'))
+                    modified_version=Subquery(latest_version.values('modified'))
                 )
-                return queryset.order_by(f'{ordering}_meta')
+                return queryset.order_by(f'{ordering}_version')
         return queryset
 
 

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -53,7 +53,7 @@ class DandisetFilterBackend(filters.OrderingFilter):
                 latest_version = Version.objects.filter(dandiset=OuterRef('pk')).order_by(
                     '-created'
                 )[:1]
-                # Get the `modified` field of each Version's associated VersionMetadata.
+                # Get the `modified` field of the latest Version's associated VersionMetadata.
                 # Append '_meta' to the field since there's already a 'modified' field on Dandisets
                 queryset = queryset.annotate(
                     modified_meta=Subquery(latest_version.values('metadata__modified'))

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -53,7 +53,8 @@ class DandisetFilterBackend(filters.OrderingFilter):
                 latest_version = Version.objects.filter(dandiset=OuterRef('pk')).order_by(
                     '-created'
                 )[:1]
-                # get the `modified` field of the most recent version
+                # get the `modified` field of the most recent version.
+                # '_version' is appended because the Dandiset model already has a `modified` field
                 queryset = queryset.annotate(
                     modified_version=Subquery(latest_version.values('modified'))
                 )


### PR DESCRIPTION
Server side changes required for https://github.com/dandi/dandiarchive/pull/732. 

As of right now, this PR determines a given dandiset's `modified` value using only the version metadata and not any of the asset metadata (see discussion [here](https://github.com/dandi/dandiarchive/pull/732#issuecomment-859722370)).