### PR TITLE
Fix publish button

### DIFF
--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -68,6 +68,8 @@ class VersionDetailSerializer(VersionSerializer):
         fields = VersionSerializer.Meta.fields + ['validation_error', 'metadata']
 
     metadata = serializers.SlugRelatedField(read_only=True, slug_field='metadata')
+    status = serializers.CharField(source='publish_status')
+    validation_error = serializers.CharField(source='publish_validation_error')
 
 
 class AssetBlobSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Previously VersionDetailSerializer was simply serializing the Version
data, so it was listing a Version as `VALID` even though it contained
assets that were not `VALID`. This made the Publish button in the UI
available even when publish was not permitted.

Add some computed properties `publish_status` and
`publish_validation_error` that check both the Version status and the
status of all Assets in the Version.

Use those fields in the `VersionDetailSerializer`.