### PR TITLE
Provide additional CLI args for Tox tools in config files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 100
 skip-string-normalization = true
 target-version = ["py38"]
-exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist'
+exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist|versioneer.py|_version.py'
 
 [tool.isort]
 profile = "black"
@@ -11,3 +11,4 @@ line_length = 100
 force_sort_within_sections = true
 # Combines "as" imports on the same line
 combine_as_imports = true
+extend_skip = ["versioneer.py", "_version.py"]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     flake8-quotes
     pep8-naming
 commands =
-    flake8 --extend-exclude versioneer.py,_version.py {posargs:.}
+    flake8 {posargs:.}
 
 [testenv:type]
 skipsdist = true
@@ -35,8 +35,8 @@ deps =
     black
     isort
 commands =
-    isort --extend-skip versioneer.py --extend-skip _version.py {posargs:.}
-    black --exclude versioneer.py|_version.py {posargs:.}
+    isort {posargs:.}
+    black {posargs:.}
 
 [testenv:test]
 passenv =
@@ -79,6 +79,9 @@ ignore =
     W503,
     # Missing docstring in *
     D10,
+extend-exclude =
+    versioneer.py,
+    _version.py,
 
 [pytest]
 DJANGO_SETTINGS_MODULE = dandiapi.settings


### PR DESCRIPTION
This has several advantages over including args inline:
* It resolves a bug where Black's `exclude` option was being overridden and Black was formatting files in the `.tox/` directory.
* All configuration for each tool is centralized in a single location.
* It makes it easier for developers to run tool commands directly, as tools will always pick up consistent options from config files.