### PR TITLE
Fix allow localhost urls

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -22,6 +22,8 @@ class DandiMixin(ConfigMixin):
 
     ACCOUNT_EMAIL_VERIFICATION = 'none'
 
+    DANDI_ALLOW_LOCALHOST_URLS = False
+
     @staticmethod
     def before_binding(configuration: Type[ComposedConfiguration]):
         # Install local apps first, to ensure any overridden resources are found first


### PR DESCRIPTION
The `DANDI_ALLOW_LOCALHOST_URLS` setting worked fine in development and test (which is where it is required), but causes build errors in Heroku because it is not defined for production builds.

Add a default `DANDI_ALLOW_LOCALHOST_URLS = False` to the `DandiMixin`