### PR TITLE
Automatically add dandiset creator as contact person

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -110,6 +110,16 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         # Strip away any computed fields
         metadata = Version.strip_metadata(metadata)
 
+        metadata['contributor'] = [
+            {
+                'name': f'{request.user.first_name} {request.user.last_name}',
+                'email': request.user.email,
+                'roleName': ['dandi:ContactPerson'],
+                'schemaKey': 'Person',
+                'includeInCitation': True,
+            }
+        ]
+
         version_metadata, created = VersionMetadata.objects.get_or_create(
             name=name,
             metadata=metadata,


### PR DESCRIPTION
Closes https://github.com/dandi/dandiarchive/issues/425. The user creating a dandiset will be automatically added as a contributor with a role of `dandi:ContactPerson` when the dandiset is initially created. 

I had to hardcode certain assumptions about the schema to accomplish this, since the API server injects the logged-in user's info into the dandiset's metadata upon creation of it, meaning that a future schema change may break this.