### PR TITLE
Fix order of `modified` sort

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -59,7 +59,8 @@ class DandisetFilterBackend(filters.OrderingFilter):
                 queryset = queryset.annotate(
                     modified_version=Subquery(latest_version.values('modified'))
                 )
-                return queryset.order_by(f'{ordering}_version')
+                # call reverse() so the default order puts more recently modified dandisets first
+                return queryset.order_by(f'{ordering}_version').reverse()
         return queryset
 
 


### PR DESCRIPTION
Make the default `modified` sorting order go from most recently modified -> least recently modified. 

Closes https://github.com/dandi/dandiarchive/issues/758.