### PR TITLE
Don't reverse queryset when sorting by "modified"

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -60,7 +60,7 @@ class DandisetFilterBackend(filters.OrderingFilter):
                     modified_version=Subquery(latest_version.values('modified'))
                 )
                 # call reverse() so the default order puts more recently modified dandisets first
-                return queryset.order_by(f'{ordering}_version').reverse()
+                return queryset.order_by(f'{ordering}_version')
         return queryset
 
 


### PR DESCRIPTION
Backend changes needed for https://github.com/dandi/dandiarchive/pull/760.