### PR TITLE
Remove linebreaks from email template <a> elements

### DIFF
--- a/dandiapi/api/migrations/0012_merge_20210630_1354.py
+++ b/dandiapi/api/migrations/0012_merge_20210630_1354.py
@@ -10,5 +10,4 @@ class Migration(migrations.Migration):
         ('api', '0011_stagingapplication'),
     ]
 
-    operations = [
-    ]
+    operations = []

--- a/dandiapi/api/templates/api/mail/added_message.html
+++ b/dandiapi/api/templates/api/mail/added_message.html
@@ -1,4 +1,2 @@
 You have been made an owner of Dandiset
-<a href="https://dandiarchive.org/dandiset/{{ dandiset_identifier }}">
-  {{ dandiset_name }}
-</a>.
+<a href="https://dandiarchive.org/dandiset/{{ dandiset_identifier }}">{{ dandiset_name }}</a>.

--- a/dandiapi/api/templates/api/mail/removed_message.html
+++ b/dandiapi/api/templates/api/mail/removed_message.html
@@ -1,4 +1,2 @@
 You have been removed as an owner of Dandiset
-<a href="https://dandiarchive.org/dandiset/{{ dandiset_identifier }}">
-  {{ dandiset_name }}
-</a>.
+<a href="https://dandiarchive.org/dandiset/{{ dandiset_identifier }}">{{ dandiset_name }}</a>.


### PR DESCRIPTION
The linebreaks cause a spurious space to appear in the linked text between the last character and the trailing period.