### PR TITLE
ENH: run dandi-cli integration testing also for staging branch

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - staging
   pull_request:
 
 jobs:


### PR DESCRIPTION
Some changes in staging broke integration with dandi-cli (and I have missed an
announcement if it was made), and now it is tricky to identify which change
broke it in the list of all the builds.  By running also on staging it
would mitigate that.

Note: might need a merge into staging to trigger?