### PR TITLE
Metadata fixes

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -140,6 +140,12 @@ class Asset(TimeStampedModel):
             'contentSize': self.blob.size,
             'digest': self.blob.digest,
         }
+        if 'schemaVersion' in metadata:
+            schema_version = metadata['schemaVersion']
+            metadata['@context'] = (
+                'https://raw.githubusercontent.com/dandi/schema/master/releases/'
+                f'{schema_version}/context.json'
+            )
         return metadata
 
     @classmethod

--- a/dandiapi/api/models/metadata.py
+++ b/dandiapi/api/models/metadata.py
@@ -12,7 +12,7 @@ class PublishableMetadataMixin:
             'endDate': now.isoformat(),
             'wasAssociatedWith': [
                 {
-                    'id': 'RRID:SCR_017571',
+                    'identifier': 'RRID:SCR_017571',
                     'name': 'DANDI API',
                     # TODO version the API
                     'version': '0.1.0',

--- a/dandiapi/api/models/metadata.py
+++ b/dandiapi/api/models/metadata.py
@@ -12,6 +12,7 @@ class PublishableMetadataMixin:
             'endDate': now.isoformat(),
             'wasAssociatedWith': [
                 {
+                    'id': uuid4().urn,
                     'identifier': 'RRID:SCR_017571',
                     'name': 'DANDI API',
                     # TODO version the API

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -199,7 +199,7 @@ class Version(TimeStampedModel):
                 **self.metadata.metadata,
                 'publishedBy': self.metadata.published_by(now),
                 'datePublished': now.isoformat(),
-                'manifestLocation': [self.dandiset_yaml_url, self.assets_yaml_url],
+                'manifestLocation': [self.assets_yaml_url],
             },
         )
 

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -1,6 +1,8 @@
 import os.path
 from uuid import uuid4
 
+from django.conf import settings
+from django.urls import reverse
 from guardian.shortcuts import assign_perm
 import pytest
 import requests
@@ -90,6 +92,30 @@ def test_asset_total_size(draft_version_factory, asset_factory, asset_blob_facto
     asset_factory()
 
     assert Asset.total_size() == asset_blob.size
+
+
+@pytest.mark.django_db
+def test_asset_populate_metadata(asset_factory, asset_metadata):
+    raw_metadata = asset_metadata.metadata
+
+    # This should trigger _populate_metadata to inject all the computed metadata fields
+    asset = asset_factory(metadata=asset_metadata)
+
+    download_url = 'https://api.dandiarchive.org' + reverse(
+        'asset-direct-download',
+        kwargs={'asset_id': str(asset.asset_id)},
+    )
+    blob_url = asset.blob.s3_url
+    assert asset.metadata.metadata == {
+        **raw_metadata,
+        'id': f'dandiasset:{asset.asset_id}',
+        'path': asset.path,
+        'identifier': str(asset.asset_id),
+        'contentUrl': [download_url, blob_url],
+        'contentSize': asset.blob.size,
+        'digest': asset.blob.digest,
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+    }
 
 
 # API Tests

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -58,6 +58,7 @@ def test_version_published_asset(asset):
             'endDate': TIMESTAMP_RE,
             'wasAssociatedWith': [
                 {
+                    'id': URN_RE,
                     'identifier': 'RRID:SCR_017571',
                     'name': 'DANDI API',
                     # TODO version the API

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -58,7 +58,7 @@ def test_version_published_asset(asset):
             'endDate': TIMESTAMP_RE,
             'wasAssociatedWith': [
                 {
-                    'id': 'RRID:SCR_017571',
+                    'identifier': 'RRID:SCR_017571',
                     'name': 'DANDI API',
                     # TODO version the API
                     'version': '0.1.0',

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -225,14 +225,14 @@ def test_dandiset_rest_create(api_client, user):
         'version': 'draft',
         'url': url,
         'citation': (
-            f'{user.first_name} {user.last_name} ({year}) {name} '
+            f'{user.last_name}, {user.first_name} ({year}) {name} '
             f'(Version draft) [Data set]. DANDI archive. {url}'
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
         'contributor': [
             {
-                'name': 'John Doe',
+                'name': 'Doe, John',
                 'email': user.email,
                 'roleName': ['dcite:ContactPerson'],
                 'schemaKey': 'Person',
@@ -305,14 +305,14 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
         'version': 'draft',
         'url': url,
         'citation': (
-            f'{admin_user.first_name} {admin_user.last_name} ({year}) {name} '
+            f'{admin_user.last_name}, {admin_user.first_name} ({year}) {name} '
             f'(Version draft) [Data set]. DANDI archive. {url}'
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
         'contributor': [
             {
-                'name': 'John Doe',
+                'name': 'Doe, John',
                 'email': admin_user.email,
                 'roleName': ['dcite:ContactPerson'],
                 'schemaKey': 'Person',

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -221,7 +221,7 @@ def test_version_publish_version(draft_version, asset):
             'endDate': TIMESTAMP_RE,
             'wasAssociatedWith': [
                 {
-                    'id': 'RRID:SCR_017571',
+                    'identifier': 'RRID:SCR_017571',
                     'name': 'DANDI API',
                     # TODO version the API
                     'version': '0.1.0',
@@ -545,7 +545,7 @@ def test_version_rest_publish(api_client, admin_user: User, draft_version: Versi
             'endDate': TIMESTAMP_RE,
             'wasAssociatedWith': [
                 {
-                    'id': 'RRID:SCR_017571',
+                    'identifier': 'RRID:SCR_017571',
                     'name': 'DANDI API',
                     # TODO version the API
                     'version': '0.1.0',

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -230,8 +230,6 @@ def test_version_publish_version(draft_version):
         'datePublished': TIMESTAMP_RE,
         'manifestLocation': [
             f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/dandisets/'
-            f'{publish_version.dandiset.identifier}/draft/dandiset.yaml',
-            f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/dandisets/'
             f'{publish_version.dandiset.identifier}/draft/assets.yaml',
         ],
         'identifier': f'DANDI:{publish_version.dandiset.identifier}',

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -200,9 +200,12 @@ def test_version_valid_with_invalid_asset(version, asset, status):
 
 
 @pytest.mark.django_db
-def test_version_publish_version(draft_version):
+def test_version_publish_version(draft_version, asset):
     # Normally the publish endpoint would inject a doi, so we must do it manually
     fake_doi = 'doi'
+
+    draft_version.assets.add(asset)
+    draft_version.save()
 
     publish_version = draft_version.publish_version
     publish_version.doi = fake_doi
@@ -241,6 +244,12 @@ def test_version_publish_version(draft_version):
         ),
         'citation': publish_version.citation(publish_version.metadata.metadata),
         'doi': fake_doi,
+        # The published_version cannot have a properly defined assetsSummary yet, since that would
+        # require having created rows the Asset-to-Version join table, which is a side affect.
+        'assetsSummary': {
+            'numberOfBytes': 0,
+            'numberOfFiles': 0,
+        },
     }
 
 
@@ -526,6 +535,57 @@ def test_version_rest_publish(api_client, admin_user: User, draft_version: Versi
     assert published_asset.published
     # The blob should be the same between the two assets
     assert asset.blob == published_asset.blob
+
+    assert published_version.metadata.metadata == {
+        **draft_version.metadata.metadata,
+        'publishedBy': {
+            'id': URN_RE,
+            'name': 'DANDI publish',
+            'startDate': TIMESTAMP_RE,
+            'endDate': TIMESTAMP_RE,
+            'wasAssociatedWith': [
+                {
+                    'id': 'RRID:SCR_017571',
+                    'name': 'DANDI API',
+                    # TODO version the API
+                    'version': '0.1.0',
+                    'schemaKey': 'Software',
+                }
+            ],
+            'schemaKey': 'PublishActivity',
+        },
+        'datePublished': TIMESTAMP_RE,
+        'manifestLocation': [
+            f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/dandisets/'
+            f'{draft_version.dandiset.identifier}/draft/assets.yaml',
+        ],
+        'identifier': f'DANDI:{draft_version.dandiset.identifier}',
+        'version': published_version.version,
+        'id': f'DANDI:{draft_version.dandiset.identifier}/{published_version.version}',
+        'url': (
+            f'https://dandiarchive.org/dandiset/{draft_version.dandiset.identifier}'
+            f'/{published_version.version}'
+        ),
+        'citation': published_version.citation(published_version.metadata.metadata),
+        'doi': f'10.80507/dandi.{draft_version.dandiset.identifier}/{published_version.version}',
+        # Once the assets are linked, assetsSummary should be computed properly
+        'assetsSummary': {
+            'schemaKey': 'AssetsSummary',
+            'numberOfBytes': 100,
+            'numberOfFiles': 1,
+            'dataStandard': [
+                {
+                    'schemaKey': 'StandardsType',
+                    'identifier': 'RRID:SCR_015242',
+                    'name': 'Neurodata Without Borders (NWB)',
+                }
+            ],
+            'approach': [],
+            'measurementTechnique': [],
+            'variableMeasured': [],
+            'species': [],
+        },
+    }
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -221,6 +221,7 @@ def test_version_publish_version(draft_version, asset):
             'endDate': TIMESTAMP_RE,
             'wasAssociatedWith': [
                 {
+                    'id': URN_RE,
                     'identifier': 'RRID:SCR_017571',
                     'name': 'DANDI API',
                     # TODO version the API
@@ -545,6 +546,7 @@ def test_version_rest_publish(api_client, admin_user: User, draft_version: Versi
             'endDate': TIMESTAMP_RE,
             'wasAssociatedWith': [
                 {
+                    'id': URN_RE,
                     'identifier': 'RRID:SCR_017571',
                     'name': 'DANDI API',
                     # TODO version the API

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -117,7 +117,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             'schemaVersion': settings.DANDI_SCHEMA_VERSION,
             'contributor': [
                 {
-                    'name': f'{request.user.first_name} {request.user.last_name}',
+                    'name': f'{request.user.last_name}, {request.user.first_name}',
                     'email': request.user.email,
                     'roleName': ['dcite:ContactPerson'],
                     'schemaKey': 'Person',

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -147,6 +147,9 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
             ]
         )
 
+        # Save again to recompute metadata, specifically assetsSummary
+        new_version.save()
+
         write_yamls.delay(new_version.id)
 
         serializer = VersionSerializer(new_version)


### PR DESCRIPTION
* manifestLocation should only have assets.yaml i think
* the published version also does not show proper assetsSummary in the metadata, so possibly something broke there.
* https://github.com/dandi/dandi-api/pull/370/files#r659029609
* @context is missing