### PR TITLE
Add github action for deploying prod on release

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,17 @@
+name: Trigger production deploy on new release
+
+on:
+  release:
+    types:
+      - published # use `published` instead of `created` b/c `created` also runs on draft releases
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "dandi-api"
+          heroku_email: ${{secrets.HEROKU_EMAIL}}


### PR DESCRIPTION
GitHub action to deploy to production automatically whenever a new release is tagged in GitHub per the [staging design doc](https://github.com/dandi/dandi-api/blob/master/doc/design/staging-1.md).

If I'm correct, this is the only "code" / `dandi-api` repo changes that need to occur for staging to be implemented for the backend, and the rest of the changes need to be made in Heroku/Terraform.

@dchiquito no rush on reviewing since we will tackle staging after publish is all squared away as discussed in person yesterday. 

TODO:
- [ ] emplace proper Github secrets