### PR TITLE
Allow HEAD requests for direct asset download

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -530,6 +530,29 @@ def test_asset_direct_download(api_client, storage, version, asset):
 
 
 @pytest.mark.django_db
+def test_asset_direct_download_head(api_client, storage, version, asset):
+    # Pretend like AssetBlob was defined with the given storage
+    AssetBlob.blob.field.storage = storage
+
+    version.assets.add(asset)
+
+    response = api_client.head(f'/api/assets/{asset.asset_id}/download/')
+
+    assert response.status_code == 302
+
+    download_url = response.get('Location')
+    assert download_url == HTTP_URL_RE
+
+    download = requests.get(download_url)
+    cd_header = download.headers.get('Content-Disposition')
+
+    assert cd_header == f'attachment; filename="{os.path.basename(asset.path)}"'
+
+    with asset.blob.blob.file.open('rb') as reader:
+        assert download.content == reader.read()
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     'path_prefix,results',
     [

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -66,7 +66,7 @@ def _download_asset(asset: Asset):
 
 
 @swagger_auto_schema()
-@api_view(['GET'])
+@api_view(['GET', 'HEAD'])
 def asset_download_view(request, asset_id):
     asset = Asset.objects.get(asset_id=asset_id)
     return _download_asset(asset)


### PR DESCRIPTION
Previously, attempting to use `HEAD` requests on the
`/assets/{asset_id}/download/` endpoint resulted in an error 405 Method
Not Allowed, which is different from the behavior of the
`/dandisets/.../versions/.../assets/.../download/` endpoint.

Fix the endpoint so that `HEAD` requests also return 302 redirects.

Fixes #380 