### PR TITLE
Disable summary stats temporarily

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -274,7 +274,7 @@ class Version(TimeStampedModel):
             'numberOfBytes': 0,
             'numberOfFiles': 0,
         }
-        if version_with_assets.id:
+        if version_with_assets.id and False:
             try:
                 summary = aggregate_assets_summary(
                     [asset.metadata.metadata for asset in version_with_assets.assets.all()]

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -274,6 +274,8 @@ class Version(TimeStampedModel):
             'numberOfBytes': 0,
             'numberOfFiles': 0,
         }
+        # TODO: remove the `and False` and find a better way to handle the
+        # unconditional recomputation of the summary stats.
         if version_with_assets.id and False:
             try:
                 summary = aggregate_assets_summary(

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -199,6 +199,7 @@ def test_validate_asset_metadata_malformed_keywords(asset: Asset):
     )
 
 
+@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
 @pytest.mark.django_db
 def test_validate_version_metadata(version: Version, asset: Asset):
     version.assets.add(asset)
@@ -241,6 +242,7 @@ def test_validate_version_metadata_malformed_schema_version(version: Version, as
     assert version.validation_error.startswith('Metadata version xxx is not allowed.')
 
 
+@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
 @pytest.mark.django_db
 def test_validate_version_metadata_no_description(version: Version, asset: Asset):
     version.assets.add(asset)
@@ -260,6 +262,7 @@ def test_validate_version_metadata_no_description(version: Version, asset: Asset
     )
 
 
+@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
 @pytest.mark.django_db
 def test_validate_version_metadata_malformed_license(version: Version, asset: Asset):
     version.assets.add(asset)

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -199,7 +199,7 @@ def test_validate_asset_metadata_malformed_keywords(asset: Asset):
     )
 
 
-@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
+@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_validate_version_metadata(version: Version, asset: Asset):
     version.assets.add(asset)
@@ -242,7 +242,7 @@ def test_validate_version_metadata_malformed_schema_version(version: Version, as
     assert version.validation_error.startswith('Metadata version xxx is not allowed.')
 
 
-@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
+@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_validate_version_metadata_no_description(version: Version, asset: Asset):
     version.assets.add(asset)
@@ -262,7 +262,7 @@ def test_validate_version_metadata_no_description(version: Version, asset: Asset
     )
 
 
-@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
+@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_validate_version_metadata_malformed_license(version: Version, asset: Asset):
     version.assets.add(asset)

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -30,6 +30,7 @@ def test_version_make_version_save(mocker, dandiset, published_version_factory):
     assert version_1.version != version_str_2
 
 
+@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
 @pytest.mark.django_db
 def test_version_metadata_computed(version, version_metadata):
     original_metadata = version_metadata.metadata
@@ -352,6 +353,7 @@ def test_version_rest_info_with_asset(
     }
 
 
+@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
 @pytest.mark.django_db
 def test_version_rest_update(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
@@ -407,6 +409,7 @@ def test_version_rest_update(api_client, user, draft_version):
     assert draft_version.metadata.name == new_name
 
 
+@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
 @pytest.mark.django_db
 def test_version_rest_update_large(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
@@ -497,6 +500,7 @@ def test_version_rest_update_not_an_owner(api_client, user, version):
     )
 
 
+@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
 @pytest.mark.django_db
 # TODO change admin_user back to a normal user once publish is allowed
 def test_version_rest_publish(api_client, admin_user: User, draft_version: Version, asset: Asset):

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -30,7 +30,7 @@ def test_version_make_version_save(mocker, dandiset, published_version_factory):
     assert version_1.version != version_str_2
 
 
-@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
+@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_version_metadata_computed(version, version_metadata):
     original_metadata = version_metadata.metadata
@@ -353,7 +353,7 @@ def test_version_rest_info_with_asset(
     }
 
 
-@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
+@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_version_rest_update(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
@@ -409,7 +409,7 @@ def test_version_rest_update(api_client, user, draft_version):
     assert draft_version.metadata.name == new_name
 
 
-@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
+@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_version_rest_update_large(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
@@ -500,7 +500,7 @@ def test_version_rest_update_not_an_owner(api_client, user, version):
     )
 
 
-@pytest.mark.skip(reason="https://github.com/dandi/dandi-api/pull/386")
+@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 # TODO change admin_user back to a normal user once publish is allowed
 def test_version_rest_publish(api_client, admin_user: User, draft_version: Version, asset: Asset):


### PR DESCRIPTION
This is a workaround to speed up the bulk updating of asset metadata in dandisets with a large number of assets.

The way the code is currently written, each asset metadata update results in an O(N) computation across all the assets, making an update of all asset metadata an O(N^2) operation in total. This workaround drops that to O(N) at the cost of not updating the summary stats.

@AlmightyYakob and @mvandenburgh helped me review this as I wrote it, so I'm formally self-reviewing and merging to master so that it appears on staging; if it behaves well there, I will promote to production so that @satra is able to speed up his process.

attn: @dchiquito

Closes #384.