### PR TITLE
Revert "Merge pull request #386 from dandi/workaround-no-summary"

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -274,9 +274,7 @@ class Version(TimeStampedModel):
             'numberOfBytes': 0,
             'numberOfFiles': 0,
         }
-        # TODO: remove the `and False` and find a better way to handle the
-        # unconditional recomputation of the summary stats.
-        if version_with_assets.id and False:
+        if version_with_assets.id:
             try:
                 summary = aggregate_assets_summary(
                     [asset.metadata.metadata for asset in version_with_assets.assets.all()]

--- a/dandiapi/api/tests/test_tasks.py
+++ b/dandiapi/api/tests/test_tasks.py
@@ -199,7 +199,6 @@ def test_validate_asset_metadata_malformed_keywords(asset: Asset):
     )
 
 
-@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_validate_version_metadata(version: Version, asset: Asset):
     version.assets.add(asset)
@@ -242,7 +241,6 @@ def test_validate_version_metadata_malformed_schema_version(version: Version, as
     assert version.validation_error.startswith('Metadata version xxx is not allowed.')
 
 
-@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_validate_version_metadata_no_description(version: Version, asset: Asset):
     version.assets.add(asset)
@@ -262,7 +260,6 @@ def test_validate_version_metadata_no_description(version: Version, asset: Asset
     )
 
 
-@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_validate_version_metadata_malformed_license(version: Version, asset: Asset):
     version.assets.add(asset)

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -30,7 +30,6 @@ def test_version_make_version_save(mocker, dandiset, published_version_factory):
     assert version_1.version != version_str_2
 
 
-@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_version_metadata_computed(version, version_metadata):
     original_metadata = version_metadata.metadata
@@ -353,7 +352,6 @@ def test_version_rest_info_with_asset(
     }
 
 
-@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_version_rest_update(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
@@ -409,7 +407,6 @@ def test_version_rest_update(api_client, user, draft_version):
     assert draft_version.metadata.name == new_name
 
 
-@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 def test_version_rest_update_large(api_client, user, draft_version):
     assign_perm('owner', user, draft_version.dandiset)
@@ -500,7 +497,6 @@ def test_version_rest_update_not_an_owner(api_client, user, version):
     )
 
 
-@pytest.mark.skip(reason='https://github.com/dandi/dandi-api/pull/386')
 @pytest.mark.django_db
 # TODO change admin_user back to a normal user once publish is allowed
 def test_version_rest_publish(api_client, admin_user: User, draft_version: Version, asset: Asset):


### PR DESCRIPTION
This reverts commit 93faf5ff2942e800bf9093b4a709c7c566ad3b1d, reversing
changes made to da32e0e6c550100a6dd8529aa68484957a710e42.

AFAIK we (@satra and me) know -- all assets metadata were converted and we should resume normal operations.  I do not expect anything to break, so I might even proceed and merge/mint a release (to get it deployed) soonish unless someone stops me