### PR TITLE
Upgrade django-click to a real dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'django>=3.1.2',
         'django-admin-display',
         'django-allauth',
+        'django-click',
         'django-configurations[database,email]',
         'django-extensions',
         'django-filter',
@@ -67,7 +68,6 @@ setup(
     ],
     extras_require={
         'dev': [
-            'django-click',
             'django-composed-configuration[dev]',
             'django-debug-toolbar',
             'django-s3-file-field[minio]',


### PR DESCRIPTION
django-click is required to run manage.py commands, which is a thing
that needs to happen in deployments as well as locally.

Move it from being a dev dependency to a real dependency.