### PR TITLE
BF: Do not install in devel mode in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # This file is only for use by Heroku, with the old pip resolver
 idna>=2.5,<3
--e .
+.


### PR DESCRIPTION
This might at least partially address a problem of incorrect version
being provided by versioneer (https://github.com/dandi/dandi-api/issues/222).
Because staging and deployment have different ways of deployment it is not
even necessary that this working on one would work on another.

More FTR: https://github.com/heroku/heroku-buildpack-python/issues/1222