### PR TITLE
Add `email-validator` as an install-required package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # This file is only for use by Heroku, with the old pip resolver
 idna>=2.5,<3
+pydantic[email]
 .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 # This file is only for use by Heroku, with the old pip resolver
 idna>=2.5,<3
+# To address an odd case of email-validator not being installed
+# see https://github.com/dandi/dandi-api/pull/405
 pydantic[email]
 .

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'djangorestframework-yaml',
         'drf-extensions',
         'drf-yasg',
-        'email-validator',
         'httpx',
         'jsonschema',
         # Production-only

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'djangorestframework-yaml',
         'drf-extensions',
         'drf-yasg',
+        'email-validator',
         'httpx',
         'jsonschema',
         # Production-only


### PR DESCRIPTION
See this [Heroku build failure](https://dashboard.heroku.com/apps/dandi-api-staging/activity/builds/e0bbf36c-0a34-47f4-b099-94fc580b49fd) for details.