### PR TITLE
Log errors when calculating assetsSummary

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -14,8 +14,6 @@ from dandiapi.api.models.metadata import PublishableMetadataMixin
 
 from .dandiset import Dandiset
 
-logger = logging.getLogger(__name__)
-
 if settings.DANDI_ALLOW_LOCALHOST_URLS:
     # If this environment variable is set, the pydantic model will allow URLs with localhost
     # in them. This is important for development and testing environments, where URLs will
@@ -23,6 +21,8 @@ if settings.DANDI_ALLOW_LOCALHOST_URLS:
     os.environ['DANDI_ALLOW_LOCALHOST_URLS'] = 'True'
 
 from dandischema.metadata import aggregate_assets_summary
+
+logger = logging.getLogger(__name__)
 
 
 class VersionMetadata(PublishableMetadataMixin, TimeStampedModel):

--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import os
 
 from django.conf import settings
@@ -12,6 +13,8 @@ from django_extensions.db.models import TimeStampedModel
 from dandiapi.api.models.metadata import PublishableMetadataMixin
 
 from .dandiset import Dandiset
+
+logger = logging.getLogger(__name__)
 
 if settings.DANDI_ALLOW_LOCALHOST_URLS:
     # If this environment variable is set, the pydantic model will allow URLs with localhost
@@ -245,7 +248,7 @@ class Version(TimeStampedModel):
             except Exception:
                 # The assets summary aggregation may fail if any asset metadata is invalid.
                 # If so, just use the placeholder summary.
-                pass
+                logger.error('Error calculating assetsSummary', exc_info=1)
 
         # Import here to avoid dependency cycle
         from dandiapi.api.manifests import manifest_location


### PR DESCRIPTION
The function that calculates `assetsSummary` can plausibly fail due to invalid asset metadata. In that case, `assetsSummary` is technically invalid and nothing was being logged, which made the error very difficult to diagnose.

Log any errors encountered when calculating `assetsSummary`.

Since this was presumably caused by invalid asset metadata, this problem should be mitigated in the future by #417 and associated frontend improvements.