### PR TITLE
select_related on asset metadata

### DIFF
--- a/dandiapi/api/models/version.py
+++ b/dandiapi/api/models/version.py
@@ -243,7 +243,10 @@ class Version(TimeStampedModel):
         if version_with_assets.id:
             try:
                 summary = aggregate_assets_summary(
-                    [asset.metadata.metadata for asset in version_with_assets.assets.all()]
+                    [
+                        asset.metadata.metadata
+                        for asset in version_with_assets.assets.select_related('metadata').all()
+                    ]
                 )
             except Exception:
                 # The assets summary aggregation may fail if any asset metadata is invalid.


### PR DESCRIPTION
Turns out that the `assetsSummary` calculation was taking a long time
because each asset metadata was being fetched from the DB separately, so
a Version with 1000 assets meant 1000 SQL queries. This `select_related`
call should roll them up into a single large query, which cuts down on
network traffic.