### PR TITLE
Fix minio URLs for running tox in docker-compose

### DIFF
--- a/dandiapi/api/tests/conftest.py
+++ b/dandiapi/api/tests/conftest.py
@@ -97,9 +97,11 @@ def minio_storage_factory() -> MinioStorage:
         bucket_name=settings.DANDI_DANDISETS_BUCKET_NAME,
         auto_create_bucket=True,
         presign_urls=True,
-        base_url=settings.MINIO_STORAGE_MEDIA_URL,
-        # TODO: Test the case of an alternate base_url
-        # base_url='http://minio:9000/bucket-name'
+        # For testing, connect to a local Minio instance
+        base_url=(
+            f'{"https" if settings.MINIO_STORAGE_USE_HTTPS else "http"}:'
+            f'//{settings.MINIO_STORAGE_ENDPOINT}'
+        ),
     )
 
 


### PR DESCRIPTION
Running `docker-compose run --rm django tox` was resulting in errors when trying to use the download URLs provided by Minio. We had encountered this error earlier for the S3 fixture, but neglected to apply that fix to the minio fixture. This error only applies when running tox in docker.