### PR TITLE
Do not allow deletion of dandisets with published versions

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -507,25 +507,24 @@ def test_dandiset_rest_delete_not_an_owner(api_client, draft_version, user):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_delete_published(api_client, published_version, admin_user):
-    api_client.force_authenticate(user=admin_user)
-
-    response = api_client.delete(f'/api/dandisets/{published_version.dandiset.identifier}/')
-    assert response.status_code == 204
-
-    assert not Dandiset.objects.all()
-
-
-@pytest.mark.django_db
-def test_dandiset_rest_delete_published_not_an_admin(api_client, published_version, user):
+def test_dandiset_rest_delete_published(api_client, published_version, user):
     api_client.force_authenticate(user=user)
     assign_perm('owner', user, published_version.dandiset)
 
     response = api_client.delete(f'/api/dandisets/{published_version.dandiset.identifier}/')
     assert response.status_code == 403
-    assert (
-        response.data == 'Non-admins are not permitted to delete dandisets with published versions.'
-    )
+    assert response.data == 'Cannot delete dandisets with published versions.'
+
+    assert published_version.dandiset in Dandiset.objects.all()
+
+
+@pytest.mark.django_db
+def test_dandiset_rest_delete_published_admin(api_client, published_version, admin_user):
+    api_client.force_authenticate(user=admin_user)
+
+    response = api_client.delete(f'/api/dandisets/{published_version.dandiset.identifier}/')
+    assert response.status_code == 403
+    assert response.data == 'Cannot delete dandisets with published versions.'
 
     assert published_version.dandiset in Dandiset.objects.all()
 

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -486,24 +486,48 @@ def test_dandiset_rest_create_with_invalid_identifier(api_client, admin_user):
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_delete(api_client, dandiset, user):
+def test_dandiset_rest_delete(api_client, draft_version, user):
     api_client.force_authenticate(user=user)
-    assign_perm('owner', user, dandiset)
+    assign_perm('owner', user, draft_version.dandiset)
 
-    response = api_client.delete(f'/api/dandisets/{dandiset.identifier}/')
+    response = api_client.delete(f'/api/dandisets/{draft_version.dandiset.identifier}/')
     assert response.status_code == 204
 
     assert not Dandiset.objects.all()
 
 
 @pytest.mark.django_db
-def test_dandiset_rest_delete_not_an_owner(api_client, dandiset, user):
+def test_dandiset_rest_delete_not_an_owner(api_client, draft_version, user):
     api_client.force_authenticate(user=user)
 
-    response = api_client.delete(f'/api/dandisets/{dandiset.identifier}/')
+    response = api_client.delete(f'/api/dandisets/{draft_version.dandiset.identifier}/')
     assert response.status_code == 403
 
-    assert dandiset in Dandiset.objects.all()
+    assert draft_version.dandiset in Dandiset.objects.all()
+
+
+@pytest.mark.django_db
+def test_dandiset_rest_delete_published(api_client, published_version, admin_user):
+    api_client.force_authenticate(user=admin_user)
+
+    response = api_client.delete(f'/api/dandisets/{published_version.dandiset.identifier}/')
+    assert response.status_code == 204
+
+    assert not Dandiset.objects.all()
+
+
+@pytest.mark.django_db
+def test_dandiset_rest_delete_published_not_an_admin(api_client, published_version, user):
+    api_client.force_authenticate(user=user)
+    assign_perm('owner', user, published_version.dandiset)
+
+    response = api_client.delete(f'/api/dandisets/{published_version.dandiset.identifier}/')
+    assert response.status_code == 403
+    assert (
+        response.data == 'Non-admins are not permitted to delete dandisets with published versions.'
+    )
+
+    assert published_version.dandiset in Dandiset.objects.all()
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -185,9 +185,9 @@ class DandisetViewSet(ReadOnlyModelViewSet):
     def destroy(self, request, dandiset__pk):
         dandiset: Dandiset = get_object_or_404(Dandiset, pk=dandiset__pk)
 
-        if dandiset.versions.filter(~Q(version='draft')).exists() and not request.user.is_superuser:
+        if dandiset.versions.filter(~Q(version='draft')).exists():
             return Response(
-                'Non-admins are not permitted to delete dandisets with published versions.',
+                'Cannot delete dandisets with published versions.',
                 status=status.HTTP_403_FORBIDDEN,
             )
 

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -2,7 +2,7 @@ import logging
 
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
-from django.db.models import OuterRef, Subquery
+from django.db.models import OuterRef, Q, Subquery
 from django.db.utils import IntegrityError
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -184,6 +184,12 @@ class DandisetViewSet(ReadOnlyModelViewSet):
     @method_decorator(permission_required_or_403('owner', (Dandiset, 'pk', 'dandiset__pk')))
     def destroy(self, request, dandiset__pk):
         dandiset: Dandiset = get_object_or_404(Dandiset, pk=dandiset__pk)
+
+        if dandiset.versions.filter(~Q(version='draft')).exists() and not request.user.is_superuser:
+            return Response(
+                'Non-admins are not permitted to delete dandisets with published versions.',
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         dandiset.delete()
         return Response(None, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
We do not want normal users to be able to delete dandisets that have been published at least once, but we still want admins to have the power if necessary.

* Update old delete endpoint tests to test dandisets with draft versions.
* Add new tests for deleting dandisets with published verisons.

Fixes #288 