### PR TITLE
Bump dandischema and replace dandi-cli dependency

### DIFF
--- a/dandiapi/api/multipart.py
+++ b/dandiapi/api/multipart.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Iterator, Tuple
 
-from dandi.core.digests.dandietag import PartGenerator
+from dandischema.digests.dandietag import PartGenerator
 from django.core.files.storage import Storage
 from s3_file_field._multipart import MultipartManager
 from s3_file_field._multipart_boto3 import Boto3MultipartManager

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'dandi>=0.12.0',
-        'dandischema>=0.2.9',
+        'dandischema>=0.3.1',
         'django>=3.1.2',
         'django-admin-display',
         'django-allauth',


### PR DESCRIPTION
dandischema has absorbed the functionality that dandi-api needed dandi-cli for, so once dandischema is bumped we can remove the dependency on dandi-cli.