### PR TITLE
Set DANDI_ALLOW_LOCALHOST_URLS for integration tests

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -41,6 +41,8 @@ jobs:
         dandi-version:
           - release
           - master
+    env:
+      DANDI_ALLOW_LOCALHOST_URLS: 1
     steps:
       - name: Download Docker image tarball
         uses: actions/download-artifact@v2


### PR DESCRIPTION
This seems necessary as https://github.com/dandi/dandi-cli/commit/7cc845d24def7025426f5d17283ec26793ed1f02 does the same thing for the dandi-cli tests.