### PR TITLE
Add top-level API endpoint for asset metadata

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -1,3 +1,4 @@
+import json
 import os.path
 from uuid import uuid4
 
@@ -205,6 +206,11 @@ def test_asset_rest_retrieve(api_client, version, asset):
             f'/api/dandisets/{version.dandiset.identifier}/'
             f'versions/{version.version}/assets/{asset.asset_id}/'
         ).data
+        == asset.metadata.metadata
+    )
+
+    assert (
+        json.loads(api_client.get(f'/api/assets/{asset.asset_id}/metadata/').content)
         == asset.metadata.metadata
     )
 

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -209,11 +209,6 @@ def test_asset_rest_retrieve(api_client, version, asset):
         == asset.metadata.metadata
     )
 
-    assert (
-        json.loads(api_client.get(f'/api/assets/{asset.asset_id}/metadata/').content)
-        == asset.metadata.metadata
-    )
-
 
 @pytest.mark.django_db
 def test_asset_rest_retrieve_no_sha256(api_client, version, asset):
@@ -632,3 +627,11 @@ def test_asset_direct_download_head(api_client, storage, version, asset):
 
     with asset.blob.blob.file.open('rb') as reader:
         assert download.content == reader.read()
+
+
+@pytest.mark.django_db
+def test_asset_direct_metadata(api_client, asset):
+    assert (
+        json.loads(api_client.get(f'/api/assets/{asset.asset_id}/metadata/').content)
+        == asset.metadata.metadata
+    )

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -632,6 +632,6 @@ def test_asset_direct_download_head(api_client, storage, version, asset):
 @pytest.mark.django_db
 def test_asset_direct_metadata(api_client, asset):
     assert (
-        json.loads(api_client.get(f'/api/assets/{asset.asset_id}/metadata/').content)
+        json.loads(api_client.get(f'/api/assets/{asset.asset_id}/').content)
         == asset.metadata.metadata
     )

--- a/dandiapi/api/views/__init__.py
+++ b/dandiapi/api/views/__init__.py
@@ -1,4 +1,4 @@
-from .asset import AssetViewSet, asset_download_view
+from .asset import AssetViewSet, asset_download_view, asset_metadata_view
 from .auth import auth_token_view
 from .dandiset import DandisetViewSet
 from .info import info_view
@@ -17,6 +17,7 @@ __all__ = [
     'DandisetViewSet',
     'VersionViewSet',
     'asset_download_view',
+    'asset_metadata_view',
     'auth_token_view',
     'blob_read_view',
     'upload_initialize_view',

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -12,7 +12,7 @@ except ImportError:
 import os.path
 
 from django.db import models, transaction
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django_filters import rest_framework as filters
@@ -72,6 +72,13 @@ def _download_asset(asset: Asset):
 def asset_download_view(request, asset_id):
     asset = Asset.objects.get(asset_id=asset_id)
     return _download_asset(asset)
+
+
+@swagger_auto_schema()
+@api_view(['GET', 'HEAD'])
+def asset_metadata_view(request, asset_id):
+    asset = get_object_or_404(Asset, asset_id=asset_id)
+    return JsonResponse(asset.metadata.metadata)
 
 
 class AssetRequestSerializer(serializers.Serializer):

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -70,7 +70,7 @@ register_converter(DandisetIDConverter, 'dandiset_id')
 urlpatterns = [
     path('api/', include(router.urls)),
     re_path(
-        r'api/assets/(?P<asset_id>[0-9a-f\-]{36})/',
+        r'api/assets/(?P<asset_id>[0-9a-f\-]{36})/$',
         asset_metadata_view,
         name='asset-direct-metadata',
     ),

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -70,7 +70,7 @@ register_converter(DandisetIDConverter, 'dandiset_id')
 urlpatterns = [
     path('api/', include(router.urls)),
     re_path(
-        r'api/assets/(?P<asset_id>[0-9a-f\-]{36})/metadata/',
+        r'api/assets/(?P<asset_id>[0-9a-f\-]{36})/',
         asset_metadata_view,
         name='asset-direct-metadata',
     ),

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -11,6 +11,7 @@ from dandiapi.api.views import (
     DandisetViewSet,
     VersionViewSet,
     asset_download_view,
+    asset_metadata_view,
     auth_token_view,
     blob_read_view,
     info_view,
@@ -68,6 +69,11 @@ class DandisetIDConverter:
 register_converter(DandisetIDConverter, 'dandiset_id')
 urlpatterns = [
     path('api/', include(router.urls)),
+    re_path(
+        r'api/assets/(?P<asset_id>[0-9a-f\-]{36})/metadata/',
+        asset_metadata_view,
+        name='asset-direct-metadata',
+    ),
     re_path(
         r'api/assets/(?P<asset_id>[0-9a-f\-]{36})/download/',
         asset_download_view,


### PR DESCRIPTION
This adds a `GET /assets/{asset_id}/metadata` endpoint to the API, allowing for querying asset metadata without specifying a dandiset ID and version.

Closes #436.