### PR TITLE
Make users inactive by default, display "Pending Approval" message

### DIFF
--- a/dandiapi/api/templates/account/account_inactive.html
+++ b/dandiapi/api/templates/account/account_inactive.html
@@ -1,0 +1,20 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}Account Pending Approval{% endblock %}
+
+{% block content %}
+<h1>Pending Approval</h1>
+<hr />
+
+<div class="pb-2 pt-5">
+  <p class="mb-5">This account has not been approved yet. Please allow 1-2 business days for approval.</p>
+  <p class="text-center">
+    <a href="https://dandiarchive.org" class="button inline-flex items-center is-primary">
+      Return to the DANDI Archive Homepage
+      <i class="ri-arrow-left-circle-line ml-3 text-xl"></i>
+    </a>
+  </p>
+</div>
+{% endblock %}

--- a/dandiapi/api/views/auth.py
+++ b/dandiapi/api/views/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from allauth.account.signals import user_signed_up
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -18,6 +19,13 @@ from rest_framework.response import Response
 def create_auth_token(sender, instance=None, created=False, **kwargs):
     if created:
         Token.objects.create(user=instance)
+
+
+@receiver(user_signed_up)
+def set_user_inactive(sender, user, **kwargs):
+    if settings.SET_NEW_USER_INACTIVE:
+        user.is_active = False
+        user.save()
 
 
 @swagger_auto_schema(

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -69,6 +69,9 @@ class DandiMixin(ConfigMixin):
     # django-composed-configuration) we can remove this setting.
     SWAGGER_SETTINGS = {}
 
+    # Don't set new users as inactive by default
+    SET_NEW_USER_INACTIVE = False
+
 
 class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
     # This makes pydantic model schema allow URLs with localhost in them.
@@ -93,6 +96,10 @@ class ProductionConfiguration(DandiMixin, ProductionBaseConfiguration):
 class HerokuProductionConfiguration(DandiMixin, HerokuProductionBaseConfiguration):
     # All login attempts in production should go straight to GitHub
     LOGIN_URL = '/accounts/github/login/'
+
+    # New user accounts in production and staging should be inactive by
+    # default (pending manual approval by a member of the DANDI team)
+    SET_NEW_USER_INACTIVE = True
 
 
 # NOTE: The staging configuration uses a custom OAuth toolkit `Application` model


### PR DESCRIPTION
Sets new users' `is_active` status to `False` in production and staging environments. DANDI team members can log into the admin console and check the `Active` checkbox to approve a new user. Note that this will not affect local dev/testing environments (i.e. users will still be `Active` by default in those environments). To test these changes locally, set this line to `True` https://github.com/dandi/dandi-api/blob/user-inactive-by-default/dandiapi/settings.py#L73

Immediately after signing up (and upon any attempt to sign in before being approved), users will see this screen:
![Screenshot from 2021-08-03 15-25-43](https://user-images.githubusercontent.com/37340715/128074607-27afe734-cfbc-49c1-b968-ea4a554f3e24.png)
 
If anyone has feedback or suggested changes for the wording, please share. In particular, I'm wasn't sure what amount of time we want to say users will be approved by (it's 1-2 business days ATM).

Closes #332 and https://github.com/dandi/dandiarchive/issues/809