### PR TITLE
Fix publish

### DIFF
--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -168,6 +168,7 @@ class Asset(TimeStampedModel):
         This is useful to validate asset metadata without saving it.
         To actually publish this Asset, simply save() after calling publish().
         """
+        # These fields need to be listed in the bulk_update() in VersionViewSet#publish.
         self.metadata = self.published_metadata()
         self.published = True
 

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -148,41 +148,28 @@ class Asset(TimeStampedModel):
             )
         return metadata
 
-    @classmethod
-    def published_asset(cls, asset: Asset):
-        """
-        Generate a published asset + metadata without saving it.
-
-        This is useful to validate asset metadata without saving it.
-        """
+    def published_metadata(self):
+        """Generate the metadata of this asset as if it were being published."""
         now = datetime.datetime.utcnow()
         # Inject the publishedBy and datePublished fields
         published_metadata, _ = AssetMetadata.objects.get_or_create(
             metadata={
-                **asset.metadata.metadata,
-                'publishedBy': asset.metadata.published_by(now),
+                **self.metadata.metadata,
+                'publishedBy': self.metadata.published_by(now),
                 'datePublished': now.isoformat(),
             },
         )
+        return published_metadata
 
-        # Create the published model
-        published_asset = Asset(
-            path=asset.path,
-            blob=asset.blob,
-            metadata=published_metadata,
-            # If we're publishing, just assume that the asset was valid
-            status=Asset.Status.VALID,
-            previous=asset,
-            published=True,
-        )
+    def publish(self):
+        """
+        Modify the metadata of this asset as if it were being published.
 
-        # Recompute the metadata
-        published_metadata, _ = AssetMetadata.objects.get_or_create(
-            metadata=published_asset._populate_metadata(),
-        )
-        published_asset.metadata = published_metadata
-
-        return published_asset
+        This is useful to validate asset metadata without saving it.
+        To actually publish this Asset, simply save() after calling publish().
+        """
+        self.metadata = self.published_metadata()
+        self.published = True
 
     def save(self, *args, **kwargs):
         metadata = self._populate_metadata()

--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -93,8 +93,7 @@ def validate_asset_metadata(asset_id: int) -> None:
     asset.save()
 
     try:
-        publish_asset = Asset.published_asset(asset)
-        metadata = publish_asset.metadata.metadata
+        metadata = asset.published_metadata().metadata
         validate(metadata, schema_key='PublishedAsset')
     except Exception as e:
         logger.error('Error while validating asset %s', asset_id)

--- a/dandiapi/api/tests/conftest.py
+++ b/dandiapi/api/tests/conftest.py
@@ -12,10 +12,11 @@ from storages.backends.s3boto3 import S3Boto3Storage
 
 from .factories import (
     AssetBlobFactory,
-    AssetFactory,
     AssetMetadataFactory,
     DandisetFactory,
+    DraftAssetFactory,
     DraftVersionFactory,
+    PublishedAssetFactory,
     PublishedVersionFactory,
     SocialAccountFactory,
     UploadFactory,
@@ -28,7 +29,8 @@ if TYPE_CHECKING:
     import mypy_boto3_s3 as s3
 
 
-register(AssetFactory)
+register(PublishedAssetFactory, _name='published_asset')
+register(DraftAssetFactory, _name='draft_asset')
 register(AssetBlobFactory)
 register(AssetMetadataFactory)
 register(DandisetFactory)
@@ -40,6 +42,16 @@ register(UserFactory)
 register(SocialAccountFactory)
 register(UploadFactory)
 register(VersionMetadataFactory)
+
+
+@pytest.fixture(params=[DraftAssetFactory, PublishedAssetFactory], ids=['draft', 'published'])
+def asset_factory(request):
+    return request.param
+
+
+@pytest.fixture
+def asset(asset_factory):
+    return asset_factory()
 
 
 @pytest.fixture(params=[DraftVersionFactory, PublishedVersionFactory], ids=['draft', 'published'])

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -137,13 +137,22 @@ class AssetMetadataFactory(factory.django.DjangoModelFactory):
         return metadata
 
 
-class AssetFactory(factory.django.DjangoModelFactory):
+class DraftAssetFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Asset
 
     path = factory.Faker('file_path', extension='nwb')
     metadata = factory.SubFactory(AssetMetadataFactory)
     blob = factory.SubFactory(AssetBlobFactory)
+
+
+class PublishedAssetFactory(DraftAssetFactory):
+    @classmethod
+    def _create(cls, *args, **kwargs):
+        asset: Asset = super()._create(*args, **kwargs)
+        asset.publish()
+        asset.save()
+        return asset
 
 
 class UploadFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
Fixes #459 

* Refactor the code that generated published Assets into code that mutates a draft asset into a published asset.
* Split `AssetFactory` into `DraftAssetFactory` and `PublishedAssetFactory`
* Add a new test for the publish endpoint that publishes a draft version with a draft asset and a published asset, and verifies that those assets are handled correctly.