### PR TITLE
ENH: list supported digest algorithms in 400 error response

### DIFF
--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -38,7 +38,7 @@ def test_blob_read_bad_algorithm(api_client, asset_blob):
         format='json',
     )
     assert resp.status_code == 400
-    assert resp.data == 'Unsupported Digest Algorithm'
+    assert resp.data.startswith('Unsupported Digest Algorithm. Supported:')
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_upload.py
+++ b/dandiapi/api/tests/test_upload.py
@@ -38,7 +38,7 @@ def test_blob_read_bad_algorithm(api_client, asset_blob):
         format='json',
     )
     assert resp.status_code == 400
-    assert resp.data.startswith('Unsupported Digest Algorithm. Supported:')
+    assert resp.data == 'Unsupported Digest Algorithm. Supported: dandi:dandi-etag'
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -19,6 +19,8 @@ from dandiapi.api.models import AssetBlob, Upload
 from dandiapi.api.tasks import calculate_sha256
 from dandiapi.api.views.serializers import AssetBlobSerializer
 
+supported_digests = ('dandi:dandi-etag',)
+
 
 class DigestSerializer(serializers.Serializer):
     algorithm = serializers.CharField()
@@ -67,6 +69,8 @@ class UploadCompletionResponseSerializer(serializers.Serializer):
 
 @swagger_auto_schema(
     method='POST',
+    operation_summary='Fetch an existing asset blob by digest, if it exists.',
+    operation_description=f'Known digest algorithms: {", ".join(supported_digests)}',
     request_body=DigestSerializer(),
     responses={200: AssetBlobSerializer()},
 )
@@ -74,14 +78,12 @@ class UploadCompletionResponseSerializer(serializers.Serializer):
 @parser_classes([JSONParser])
 @permission_classes([])
 def blob_read_view(request: Request) -> HttpResponseBase:
-    """Fetch an existing asset blob by digest, if it exists."""
     request_serializer = DigestSerializer(data=request.data)
     request_serializer.is_valid(raise_exception=True)
-    supported_digests = ('dandi:dandi-etag',)
     if request_serializer.validated_data['algorithm'] not in supported_digests:
         return Response(
             f'Unsupported Digest Algorithm. Supported: {", ".join(supported_digests)}',
-            status=400
+            status=400,
         )
     etag = request_serializer.validated_data['value']
 

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -77,8 +77,12 @@ def blob_read_view(request: Request) -> HttpResponseBase:
     """Fetch an existing asset blob by digest, if it exists."""
     request_serializer = DigestSerializer(data=request.data)
     request_serializer.is_valid(raise_exception=True)
-    if request_serializer.validated_data['algorithm'] != 'dandi:dandi-etag':
-        return Response('Unsupported Digest Algorithm', status=400)
+    supported_digests = ('dandi:dandi-etag',)
+    if request_serializer.validated_data['algorithm'] not in supported_digests:
+        return Response(
+            f'Unsupported Digest Algorithm. Supported: {", ".join(supported_digests)}',
+            status=400
+        )
     etag = request_serializer.validated_data['value']
 
     asset_blob = get_object_or_404(AssetBlob, etag=etag)

--- a/dandiapi/api/views/upload.py
+++ b/dandiapi/api/views/upload.py
@@ -70,7 +70,7 @@ class UploadCompletionResponseSerializer(serializers.Serializer):
 @swagger_auto_schema(
     method='POST',
     operation_summary='Fetch an existing asset blob by digest, if it exists.',
-    operation_description=f'Known digest algorithms: {", ".join(supported_digests)}',
+    operation_description=f'Supported digest algorithms: {", ".join(supported_digests)}',
     request_body=DigestSerializer(),
     responses={200: AssetBlobSerializer()},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,9 @@ ignore =
     # Missing docstring in *
     D10,
 extend-exclude =
+    build,
+    dist,
+    venvs,
     versioneer.py,
     _version.py,
 


### PR DESCRIPTION
See https://github.com/dandi/dandi-api/issues/468 as a motivator for
introducing this change.  In general I really prefer informative error
messages which can help user to immediately resolve the "problem"
without RTFM etc.  Hence I think besides improving documentation
(no information on what algorithms are supported is shown), error
should be improved as well.

2nd commit adds that listing also to operation_description ~~the docstring... can't test locally ATM if works out as expected~~