### PR TITLE
Remove incorrect param in swagger doc

### DIFF
--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -101,7 +101,6 @@ class DandisetViewSet(ReadOnlyModelViewSet):
     @swagger_auto_schema(
         request_body=VersionMetadataSerializer(),
         responses={200: DandisetDetailSerializer()},
-        manual_parameters=[DANDISET_PK_PARAM],
         operation_summary='Create a new dandiset.',
         operation_description='',
     )


### PR DESCRIPTION
There was a path param in the swagger docs that isn't actually part of the endpoint. 