### PR TITLE
Add script to migrate metadata of published dandisets

### DIFF
--- a/dandiapi/api/management/commands/migrate_published_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_published_version_metadata.py
@@ -29,8 +29,8 @@ def migrate_published_version_metadata(dandiset: str, published_version: str):
     try:
         metanew = migrate(metadata, to_version=settings.DANDI_SCHEMA_VERSION, skip_validation=False)
     except Exception as e:
-        print(f'Failed to migrate {dandiset}/{published_version}')
-        print(e)
+        click.echo(f'Failed to migrate {dandiset}/{published_version}')
+        click.echo(e)
         raise click.Abort()
 
     if metadata == metanew:

--- a/dandiapi/api/management/commands/migrate_published_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_published_version_metadata.py
@@ -1,0 +1,56 @@
+from pprint import pformat
+from difflib import ndiff
+
+from dandischema import migrate
+from django.conf import settings
+from django.db.models import Q
+import djclick as click
+
+from dandiapi.api.models import Version
+from dandiapi.api.tasks import write_manifest_files
+
+
+@click.command()
+@click.argument('dandiset')
+@click.argument('published_version')
+def migrate_published_version_metadata(dandiset: str, published_version: str):
+    click.echo(
+        f'Migrating published version {dandiset}/{published_version} metadata to version {settings.DANDI_SCHEMA_VERSION}'
+    )
+    version = Version.objects.filter(~Q(version='draft')).get(
+        dandiset=dandiset, version=published_version
+    )
+    metadata = version.metadata
+
+    # If there is no schemaVersion, assume the most recent
+    if 'schemaVersion' not in metadata:
+        metadata['schemaVersion'] = settings.DANDI_SCHEMA_VERSION
+
+    try:
+        metanew = migrate(metadata, to_version=settings.DANDI_SCHEMA_VERSION, skip_validation=False)
+    except Exception as e:
+        print(f'Failed to migrate {dandiset}/{published_version}')
+        print(e)
+        raise click.Abort()
+
+    if metadata == metanew:
+        click.echo('No changes detected')
+    else:
+        click.echo('Diff of changes to be saved:')
+        click.echo(
+            ''.join(
+                ndiff(
+                    pformat(metadata).splitlines(keepends=True),
+                    pformat(metanew).splitlines(keepends=True),
+                )
+            )
+        )
+
+        click.confirm('Do you want to save these changes?', abort=True)
+
+        version.metadata = metanew
+        version.save()
+
+        write_manifest_files.delay(version.id)
+
+        # We don't bother revalidating here because it's already published

--- a/dandiapi/api/management/commands/migrate_published_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_published_version_metadata.py
@@ -1,8 +1,7 @@
-from pprint import pformat
 from difflib import ndiff
+from pprint import pformat
 
 from dandischema import migrate
-from django.conf import settings
 from django.db.models import Q
 import djclick as click
 
@@ -13,9 +12,10 @@ from dandiapi.api.tasks import write_manifest_files
 @click.command()
 @click.argument('dandiset')
 @click.argument('published_version')
-def migrate_published_version_metadata(dandiset: str, published_version: str):
+@click.argument('to_version')
+def migrate_published_version_metadata(dandiset: str, published_version: str, to_version: str):
     click.echo(
-        f'Migrating published version {dandiset}/{published_version} metadata to version {settings.DANDI_SCHEMA_VERSION}'
+        f'Migrating published version {dandiset}/{published_version} metadata to version {to_version}'  # noqa: E501
     )
     version = Version.objects.filter(~Q(version='draft')).get(
         dandiset=dandiset, version=published_version
@@ -24,10 +24,10 @@ def migrate_published_version_metadata(dandiset: str, published_version: str):
 
     # If there is no schemaVersion, assume the most recent
     if 'schemaVersion' not in metadata:
-        metadata['schemaVersion'] = settings.DANDI_SCHEMA_VERSION
+        metadata['schemaVersion'] = to_version
 
     try:
-        metanew = migrate(metadata, to_version=settings.DANDI_SCHEMA_VERSION, skip_validation=False)
+        metanew = migrate(metadata, to_version=to_version, skip_validation=False)
     except Exception as e:
         click.echo(f'Failed to migrate {dandiset}/{published_version}')
         click.echo(e)

--- a/dandiapi/api/management/commands/migrate_published_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_published_version_metadata.py
@@ -22,7 +22,7 @@ def migrate_published_version_metadata(dandiset: str, published_version: str, to
     )
     metadata = version.metadata
 
-    # If there is no schemaVersion, assume the most recent
+    # If there is no schemaVersion, assume to_version
     if 'schemaVersion' not in metadata:
         metadata['schemaVersion'] = to_version
 


### PR DESCRIPTION
This script will migrate the metadata of a specific published version. It will show the diff first and request confirmation. It will also trigger the rewrite of the .yaml and .jsonld files.