### PR TITLE
CORS signal handler

### DIFF
--- a/dandiapi/api/__init__.py
+++ b/dandiapi/api/__init__.py
@@ -3,3 +3,4 @@
 # Import here to register any signal handlers
 import dandiapi.api.mail
 import dandiapi.api.user_migration
+import dandiapi.api.signals

--- a/dandiapi/api/__init__.py
+++ b/dandiapi/api/__init__.py
@@ -3,4 +3,3 @@
 # Import here to register any signal handlers
 import dandiapi.api.mail
 import dandiapi.api.user_migration
-import dandiapi.api.signals

--- a/dandiapi/api/__init__.py
+++ b/dandiapi/api/__init__.py
@@ -1,5 +1,3 @@
 # flake8: noqa
 # TODO remove this after migration is complete
-# Import here to register any signal handlers
-import dandiapi.api.mail
 import dandiapi.api.user_migration

--- a/dandiapi/api/apps.py
+++ b/dandiapi/api/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class PublishConfig(AppConfig):
     name = 'dandiapi.api'
     verbose_name = 'DANDI: Publish'
+
+    def ready(self):
+        import dandiapi.api.signals  # noqa: F401

--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -1,9 +1,7 @@
 import logging
 from typing import List
 
-from allauth.account.signals import user_signed_up
 from django.core import mail
-from django.dispatch import receiver
 from django.template.loader import render_to_string
 
 logger = logging.getLogger(__name__)
@@ -69,9 +67,3 @@ def send_registered_notice_email(user, socialaccount):
     messages = [build_registered_message(user, socialaccount)]
     with mail.get_connection() as connection:
         connection.send_messages(messages)
-
-
-@receiver(user_signed_up)
-def user_signed_up_listener(sender, user, **kwargs):
-    for socialaccount in user.socialaccount_set.all():
-        send_registered_notice_email(user, socialaccount)

--- a/dandiapi/api/signals.py
+++ b/dandiapi/api/signals.py
@@ -1,0 +1,9 @@
+from corsheaders.signals import check_request_enabled
+
+
+def cors_allow_anyone_read_only(sender, request, **kwargs):
+    """Allow any read-only request from any origin."""
+    return request.method in ('GET', 'HEAD', 'OPTIONS')
+
+
+check_request_enabled.connect(cors_allow_anyone_read_only)

--- a/dandiapi/api/signals.py
+++ b/dandiapi/api/signals.py
@@ -1,9 +1,18 @@
 from corsheaders.signals import check_request_enabled
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
 
 
+@receiver(check_request_enabled)
 def cors_allow_anyone_read_only(sender, request, **kwargs):
     """Allow any read-only request from any origin."""
     return request.method in ('GET', 'HEAD', 'OPTIONS')
 
 
-check_request_enabled.connect(cors_allow_anyone_read_only)
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    """Create an auth token for every new user."""
+    if created:
+        Token.objects.create(user=instance)

--- a/dandiapi/api/signals.py
+++ b/dandiapi/api/signals.py
@@ -23,5 +23,6 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
 
 @receiver(user_signed_up)
 def user_signed_up_listener(sender, user, **kwargs):
+    """Send a registration notice email whenever a user signs up."""
     for socialaccount in user.socialaccount_set.all():
         send_registered_notice_email(user, socialaccount)

--- a/dandiapi/api/signals.py
+++ b/dandiapi/api/signals.py
@@ -5,13 +5,13 @@ from django.dispatch import receiver
 from rest_framework.authtoken.models import Token
 
 
-@receiver(check_request_enabled)
+@receiver(check_request_enabled, dispatch_uid='cors_allow_anyone_read_only')
 def cors_allow_anyone_read_only(sender, request, **kwargs):
     """Allow any read-only request from any origin."""
     return request.method in ('GET', 'HEAD', 'OPTIONS')
 
 
-@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+@receiver(post_save, sender=settings.AUTH_USER_MODEL, dispatch_uid='create_auth_token')
 def create_auth_token(sender, instance=None, created=False, **kwargs):
     """Create an auth token for every new user."""
     if created:

--- a/dandiapi/api/signals.py
+++ b/dandiapi/api/signals.py
@@ -1,8 +1,11 @@
+from allauth.account.signals import user_signed_up
 from corsheaders.signals import check_request_enabled
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from rest_framework.authtoken.models import Token
+
+from dandiapi.api.mail import send_registered_notice_email
 
 
 @receiver(check_request_enabled, dispatch_uid='cors_allow_anyone_read_only')
@@ -16,3 +19,9 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
     """Create an auth token for every new user."""
     if created:
         Token.objects.create(user=instance)
+
+
+@receiver(user_signed_up)
+def user_signed_up_listener(sender, user, **kwargs):
+    for socialaccount in user.socialaccount_set.all():
+        send_registered_notice_email(user, socialaccount)

--- a/dandiapi/api/views/auth.py
+++ b/dandiapi/api/views/auth.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from django.conf import settings
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.http.response import HttpResponseBase
 from django.shortcuts import get_object_or_404
 from drf_yasg.utils import swagger_auto_schema
@@ -11,13 +8,6 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-
-
-# TODO: put this somewhere more appropriate
-@receiver(post_save, sender=settings.AUTH_USER_MODEL)
-def create_auth_token(sender, instance=None, created=False, **kwargs):
-    if created:
-        Token.objects.create(user=instance)
 
 
 @swagger_auto_schema(


### PR DESCRIPTION
Fixes #256 

* Add a signal handler that allows an CORS requests from any origin with method `GET`, `HEAD`, or `OPTIONS`.
* Move our other signal handlers into one location, `signals.py`.