### PR TITLE
Deploy to staging with GitHub Action

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,17 @@
+name: Trigger staging deploy on push to master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "dandi-api-staging"
+          heroku_email: ${{secrets.HEROKU_EMAIL}}


### PR DESCRIPTION
Deploys staging with a GitHub Action instead of using Heroku's automatic github deployment.

Auto-deploy will need to be turned off in Heroku right before merging this (Deploy tab -> Deployment method -> Deselect "GitHub").

Closes #404.

### TODO
- [ ] turn off autodeploy on Heroku