### PR TITLE
ENH(UX): overload @swagger_auto_schema to show one-line docstrings as summary

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -10,6 +10,7 @@ from composed_configuration import (
     TestingBaseConfiguration,
 )
 from configurations import values
+from drf_yasg.inspectors import SwaggerAutoSchema
 
 
 class DandiMixin(ConfigMixin):
@@ -67,7 +68,9 @@ class DandiMixin(ConfigMixin):
     #
     # When Brian Helba is able to resolve this problem upstream (in
     # django-composed-configuration) we can remove this setting.
-    SWAGGER_SETTINGS = {}
+    SWAGGER_SETTINGS = {
+        'DEFAULT_AUTO_SCHEMA_CLASS': 'dandiapi.settings.DANDISwaggerAutoSchema',
+    }
 
 
 class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
@@ -107,3 +110,19 @@ class HerokuStagingConfiguration(HerokuProductionConfiguration):
     # We are using cheaper Heroku dynos for staging, so we need to artificially lower the number
     # of concurrent tasks (default is 8) to keep memory usage down.
     CELERY_WORKER_CONCURRENCY = 2
+
+
+class DANDISwaggerAutoSchema(SwaggerAutoSchema):
+    """Custom class for @swagger_auto_schema to provide summary from one line docstrings.
+
+    See https://github.com/axnsan12/drf-yasg/issues/205 and
+    https://github.com/axnsan12/drf-yasg/issues/265 for more information on why it is not
+    a default behavior.
+    """
+
+    def split_summary_from_description(self, description):
+        summary, description = super().split_summary_from_description(description)
+        if summary is None:
+            return description, None
+        else:
+            return summary, description

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -10,7 +10,6 @@ from composed_configuration import (
     TestingBaseConfiguration,
 )
 from configurations import values
-from drf_yasg.inspectors import SwaggerAutoSchema
 
 
 class DandiMixin(ConfigMixin):
@@ -69,7 +68,7 @@ class DandiMixin(ConfigMixin):
     # When Brian Helba is able to resolve this problem upstream (in
     # django-composed-configuration) we can remove this setting.
     SWAGGER_SETTINGS = {
-        'DEFAULT_AUTO_SCHEMA_CLASS': 'dandiapi.settings.DANDISwaggerAutoSchema',
+        'DEFAULT_AUTO_SCHEMA_CLASS': 'dandiapi.swagger.DANDISwaggerAutoSchema',
     }
 
 
@@ -110,19 +109,3 @@ class HerokuStagingConfiguration(HerokuProductionConfiguration):
     # We are using cheaper Heroku dynos for staging, so we need to artificially lower the number
     # of concurrent tasks (default is 8) to keep memory usage down.
     CELERY_WORKER_CONCURRENCY = 2
-
-
-class DANDISwaggerAutoSchema(SwaggerAutoSchema):
-    """Custom class for @swagger_auto_schema to provide summary from one line docstrings.
-
-    See https://github.com/axnsan12/drf-yasg/issues/205 and
-    https://github.com/axnsan12/drf-yasg/issues/265 for more information on why it is not
-    a default behavior.
-    """
-
-    def split_summary_from_description(self, description):
-        summary, description = super().split_summary_from_description(description)
-        if summary is None:
-            return description, None
-        else:
-            return summary, description

--- a/dandiapi/swagger.py
+++ b/dandiapi/swagger.py
@@ -1,0 +1,19 @@
+# Separate from settings.py due to being a somewhat of a premature import there.
+# See https://github.com/dandi/dandi-api/pull/482#issuecomment-901250541 .
+from drf_yasg.inspectors import SwaggerAutoSchema
+
+
+class DANDISwaggerAutoSchema(SwaggerAutoSchema):
+    """Custom class for @swagger_auto_schema to provide summary from one line docstrings.
+
+    See https://github.com/axnsan12/drf-yasg/issues/205 and
+    https://github.com/axnsan12/drf-yasg/issues/265 for more information on why it is not
+    a default behavior.
+    """
+
+    def split_summary_from_description(self, description):
+        summary, description = super().split_summary_from_description(description)
+        if summary is None:
+            return description, None
+        else:
+            return summary, description


### PR DESCRIPTION
A follow up to https://github.com/dandi/dandi-api/pull/480#discussion_r689903879

More information/references in the DANDISwaggerAutoSchema docstring.

Without such an overload, any oneline docstring is not used as an action
summary but rather as a description, so not visible until that action is
"clicked on" in the swagger interface.

compare 
![image](https://user-images.githubusercontent.com/39889/129771776-3026bd26-5750-4ec6-b6e1-1986c5ce5d23.png)

to
![image](https://user-images.githubusercontent.com/39889/129771833-3e461764-0936-49b6-a233-031b6e7d555e.png)
