### PR TITLE
Make `DEBUG` setting configurable w/ env var in development

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -74,6 +74,8 @@ class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
     # This makes pydantic model schema allow URLs with localhost in them.
     DANDI_ALLOW_LOCALHOST_URLS = True
 
+    DEBUG = values.BooleanValue(environ=True, default=True)
+
 
 class TestingConfiguration(DandiMixin, TestingBaseConfiguration):
     MINIO_STORAGE_MEDIA_BUCKET_NAME = 'test-django-storage'


### PR DESCRIPTION
The Django debug toolbar interferes with the puppeteer e2e tests in the dandiarchive repo. This PR allows the `DEBUG` setting to be optionally configured via an environment variable. This only affects development.