### PR TITLE
Add create_dev_dandiset script

### DIFF
--- a/dandiapi/api/management/commands/create_dev_dandiset.py
+++ b/dandiapi/api/management/commands/create_dev_dandiset.py
@@ -1,0 +1,69 @@
+from uuid import uuid4
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+import djclick as click
+
+from dandiapi.api.models import Asset, AssetBlob, Dandiset, Version
+from dandiapi.api.tasks import calculate_sha256, validate_asset_metadata, validate_version_metadata
+
+
+@click.command()
+@click.option('--name', default='Development Dandiset')
+@click.option('--owner', required=True, help='The email address of the owner')
+def create_dev_dandiset(name: str, owner: str):
+    owner = User.objects.get(email=owner)
+
+    # Create a new dandiset
+    dandiset = Dandiset()
+    dandiset.save()
+    dandiset.add_owner(owner)
+
+    # Create the draft version
+    version_metadata = {
+        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'description': 'An informative description',
+        'license': ['spdx:CC0-1.0'],
+        'contributor': [
+            {
+                'name': f'{owner.last_name}, {owner.first_name}',
+                'email': owner.email,
+                'roleName': ['dcite:ContactPerson'],
+                'schemaKey': 'Person',
+                'affiliation': [],
+                'includeInCitation': True,
+            },
+        ],
+    }
+    draft_version = Version(
+        dandiset=dandiset,
+        name=name,
+        metadata=version_metadata,
+        version='draft',
+    )
+    draft_version.save()
+
+    uploaded_file = SimpleUploadedFile(name='/foo/bar.txt', content=b'A' * 20)
+    etag = '76d36e98f312e98ff908c8c82c8dd623-0'
+    try:
+        asset_blob = AssetBlob.objects.get(etag=etag)
+    except AssetBlob.DoesNotExist:
+        asset_blob = AssetBlob(
+            blob_id=uuid4(),
+            blob=uploaded_file,
+            etag=etag,
+            size=20,
+        )
+        asset_blob.save()
+    asset_metadata = {
+        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'encodingFormat': 'text/plain',
+    }
+    asset = Asset(blob=asset_blob, metadata=asset_metadata, path='/foo/bar.txt')
+    asset.save()
+    draft_version.assets.add(asset)
+
+    calculate_sha256(blob_id=asset_blob.blob_id)
+    validate_asset_metadata(asset_id=asset.id)
+    validate_version_metadata(version_id=draft_version.id)

--- a/dandiapi/api/management/commands/create_dev_dandiset.py
+++ b/dandiapi/api/management/commands/create_dev_dandiset.py
@@ -44,7 +44,7 @@ def create_dev_dandiset(name: str, owner: str):
     )
     draft_version.save()
 
-    uploaded_file = SimpleUploadedFile(name='/foo/bar.txt', content=b'A' * 20)
+    uploaded_file = SimpleUploadedFile(name='foo/bar.txt', content=b'A' * 20)
     etag = '76d36e98f312e98ff908c8c82c8dd623-0'
     try:
         asset_blob = AssetBlob.objects.get(etag=etag)
@@ -60,7 +60,7 @@ def create_dev_dandiset(name: str, owner: str):
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
         'encodingFormat': 'text/plain',
     }
-    asset = Asset(blob=asset_blob, metadata=asset_metadata, path='/foo/bar.txt')
+    asset = Asset(blob=asset_blob, metadata=asset_metadata, path='foo/bar.txt')
     asset.save()
     draft_version.assets.add(asset)
 

--- a/dandiapi/api/tests/test_create_dev_dandiset.py
+++ b/dandiapi/api/tests/test_create_dev_dandiset.py
@@ -1,0 +1,27 @@
+import pytest
+
+from dandiapi.api.management.commands.create_dev_dandiset import create_dev_dandiset
+from dandiapi.api.models import Asset, AssetBlob, Dandiset, Version
+
+
+@pytest.mark.django_db
+def test_create_dev_dandiset(user):
+    create_dev_dandiset('--name', 'My Test Dandiset', '--owner', user.email)
+
+    assert Dandiset.objects.count() == 1
+    dandiset = Dandiset.objects.get()
+    assert user in dandiset.owners
+
+    assert Version.objects.count() == 1
+    version = Version.objects.get()
+    assert version.dandiset == dandiset
+    assert version.version == 'draft'
+    assert version.status == Version.Status.VALID
+
+    assert Asset.objects.count() == 1
+    asset = Asset.objects.get()
+    assert asset in version.assets.all()
+
+    assert AssetBlob.objects.count() == 1
+    asset_blob = AssetBlob.objects.get()
+    assert AssetBlob.blob.field.storage.exists(asset_blob.blob.name)


### PR DESCRIPTION
I decided to manually create the test data because the only alternatives I could think of involved dandi-cli, which is a new dependency and is subject to API changes.

If we ever change the structure of anything, the test should catch it.

Fixes #287 