### PR TITLE
Use get_object_or_404 in views

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -80,7 +80,7 @@ def _download_asset(asset: Asset):
 )
 @api_view(['GET', 'HEAD'])
 def asset_download_view(request, asset_id):
-    asset = Asset.objects.get(asset_id=asset_id)
+    asset = get_object_or_404(Asset, asset_id=asset_id)
     return _download_asset(asset)
 
 
@@ -229,7 +229,8 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
     def update(self, request, versions__dandiset__pk, versions__version, **kwargs):
         """Update the metadata of an asset."""
         old_asset = self.get_object()
-        version = Version.objects.get(
+        version = get_object_or_404(
+            Version,
             dandiset__pk=versions__dandiset__pk,
             version=versions__version,
         )
@@ -305,8 +306,10 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
     )
     def destroy(self, request, versions__dandiset__pk, versions__version, **kwargs):
         asset = self.get_object()
-        version = Version.objects.get(
-            dandiset__pk=versions__dandiset__pk, version=versions__version
+        version = get_object_or_404(
+            Version,
+            dandiset__pk=versions__dandiset__pk,
+            version=versions__version,
         )
         if version.version != 'draft':
             return Response(


### PR DESCRIPTION
This results in 404 errors instead of 500 errors when an object cannot
be found in the DB.

Fixes #486 