### PR TITLE
ENH: make github ID into a hyperlink in html version of the email

### DIFF
--- a/dandiapi/api/templates/api/mail/registered_message.html
+++ b/dandiapi/api/templates/api/mail/registered_message.html
@@ -1,4 +1,4 @@
-<p>Dear {{ name }} (Github ID: {{ github_id }}),</p>
+<p>Dear {{ name }} (Github ID: <a href="https://github.com/{{ github_id }}">{{ github_id }})</a>,</p>
 <p>Welcome to DANDI. </p>
 <p>You are now registered on the DANDI archive. Registering allows you to create Dandisets and upload data right away. You can also use the Jupyterhub (<a href="https://hub.dandiarchive.org">https://hub.dandiarchive.org</a>) for computing on dandisets in the cloud. </p>
 <p>It may take up to 24 hours for your hub account to be activated and for your email to be registered with our Slack workspace.</p>


### PR DESCRIPTION
Would assist with reviewing registered users, so could be just clicked on
to review that user github page