### PR TITLE
Pass `--config=tox.ini` to flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     flake8-quotes
     pep8-naming
 commands =
-    flake8 {posargs:.}
+    flake8 --config=tox.ini {posargs:.}
 
 [testenv:type]
 skipsdist = true


### PR DESCRIPTION
By default, if a developer (say, me) has a user-wide flake8 config file in `~/.config/flake8`, then the flake8 command in `tox.ini` will pick it up and merge the settings there with the ones in `tox.ini`, which often doesn't work out too well.  This PR instructs flake8 to only use the configuration in the `tox.ini` file and ignore any user config.