### PR TITLE
Bump dandischema to 0.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'dandischema>=0.3.2',
+        'dandischema>=0.3.3',
         'django>=3.1.2',
         'django-admin-display',
         'django-allauth',


### PR DESCRIPTION
This is required to include
https://github.com/dandi/dandischema/pull/81, which fixes
https://github.com/dandi/dandischema/issues/80, which broke publish in
some cases.

@satra This should fix Alessio's problems with publishing https://gui.dandiarchive.org/#/dandiset/000034 after it is released.