### PR TITLE
Management script to copy dandisets from another api deployment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,10 +27,22 @@ This script is a simple way to get test data into your DB without having to use 
 
 ### import_dandisets
 ```
-python manage.py import_dandisets [API_URL]
+python manage.py import_dandisets [API_URL] --all
 ```
 
 This imports all dandisets (versions + metadata only, no assets) from the dandi-api deployment
 living at `API_URL`. For example, to import all dandisets from the production server into your
 local dev environment, run `python manage.py import_dandisets http://api.dandiarchive.org` from
 your local terminal.
+
+```
+python manage.py import_dandisets [API_URL] --identifier 000005
+```
+
+This imports dandiset 000005 from `API_URL` into your local dev environment.
+
+```
+python manage.py import_dandisets [API_URL] --identifier 000005 --replace 000001
+```
+
+This imports dandiset 000005 from `API_URL` and replaces 000001 with it in your local dev environment.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,3 +24,13 @@ python manage.py create_dev_dandiset --owner your.email@email.com --name My Dumm
 This creates a dummy dandiset with valid metadata and a single dummy asset.
 The dandiset should be valid and publishable out of the box.
 This script is a simple way to get test data into your DB without having to use dandi-cli.
+
+### import_dandisets
+```
+python manage.py import_dandisets [API_URL]
+```
+
+This imports all dandisets (versions + metadata only, no assets) from the dandi-api deployment
+living at `API_URL`. For example, to import all dandisets from the production server into your
+local dev environment, run `python manage.py import_dandisets http://api.dandiarchive.org` from
+your local terminal.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,25 +33,28 @@ python manage.py import_dandisets [API_URL] --all
 This imports all dandisets (versions + metadata only, no assets) from the dandi-api deployment
 living at `API_URL`. For example, to import all dandisets from the production server into your
 local dev environment, run `python manage.py import_dandisets http://api.dandiarchive.org` from
-your local terminal.
+your local terminal. Note that if a dandiset with the same identifier as the one being imported
+already exists, that dandiset will not be imported.
+
+```
+python manage.py import_dandisets [API_URL] --all --replace
+```
+
+Same as the previous example, except if a dandiset with the same identifier as the one being imported
+already exists, the existing dandiset will be replaced with the one being imported.
 
 ```
 python manage.py import_dandisets [API_URL] --all --offset 100000
 ```
 
 This imports all dandisets (versions + metadata only, no assets) from the dandi-api deployment
-living at `API_URL` and offsets their identifiers by 100000. In this case, if the most recent dandiset
-in your local deployment has an identifier of 0000020, the first imported dandiset would have an
-identifier of 100020, second would have an identifier of 100021, etc.
+living at `API_URL` and offsets their identifiers by 100000. This is helpful if you want to import
+a dandiset that has the same identifier as one already in your database.
 
 ```
 python manage.py import_dandisets [API_URL] --identifier 000005
 ```
 
-This imports dandiset 000005 from `API_URL` into your local dev environment.
-
-```
-python manage.py import_dandisets [API_URL] --identifier 000005 --replace 000001
-```
-
-This imports dandiset 000005 from `API_URL` and replaces 000001 with it in your local dev environment.
+This imports dandiset 000005 from `API_URL` into your local dev environment. Note that if there is already
+a dandiset with an identifier of 000005, nothing will happen. Use the --replace flag to have the script
+overwrite it instead if desired.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,6 +36,15 @@ local dev environment, run `python manage.py import_dandisets http://api.dandiar
 your local terminal.
 
 ```
+python manage.py import_dandisets [API_URL] --all --offset 100000
+```
+
+This imports all dandisets (versions + metadata only, no assets) from the dandi-api deployment
+living at `API_URL` and offsets their identifiers by 100000. In this case, if the most recent dandiset
+in your local deployment has an identifier of 0000020, the first imported dandiset would have an
+identifier of 100020, second would have an identifier of 100021, etc.
+
+```
 python manage.py import_dandisets [API_URL] --identifier 000005
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,7 @@ python manage.py import_dandisets [API_URL] --all
 
 This imports all dandisets (versions + metadata only, no assets) from the dandi-api deployment
 living at `API_URL`. For example, to import all dandisets from the production server into your
-local dev environment, run `python manage.py import_dandisets http://api.dandiarchive.org` from
+local dev environment, run `python manage.py import_dandisets https://api.dandiarchive.org` from
 your local terminal. Note that if a dandiset with the same identifier as the one being imported
 already exists, that dandiset will not be imported.
 

--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -1,10 +1,31 @@
 from urllib.parse import urljoin
 
-from django.db import transaction
+from django.db import connection, transaction
+from django.db.utils import OperationalError
 import djclick as click
 import requests
 
 from dandiapi.api.models import Dandiset, Version
+from dandiapi.api.tasks import validate_version_metadata
+
+
+@transaction.atomic
+def set_sequence_value(new_value: int):
+    """Set api_dandiset_id_seq value."""
+    cursor = connection.cursor()
+    cursor.execute(f'ALTER SEQUENCE api_dandiset_id_seq RESTART WITH {new_value}')
+
+
+@transaction.atomic
+def get_sequence_value():
+    """Get current api_dandiset_id_seq value."""
+    cursor = connection.cursor()
+    try:
+        cursor.execute('SELECT last_value FROM api_dandiset_id_seq')
+    except OperationalError:
+        cursor.execute('CREATE SEQUENCE api_dandiset_id_seq START 1')
+        cursor.execute('SELECT last_value FROM api_dandiset_id_seq')
+    return cursor.fetchone()[0]
 
 
 @transaction.atomic
@@ -39,7 +60,10 @@ def import_versions_from_response(api_url: str, version_api_response: dict, dand
 
 @transaction.atomic
 def import_dandiset_from_response(
-    api_url: str, dandiset_api_response: dict, dandiset_to_replace=None, skip_existing_names=True
+    api_url: str,
+    dandiset_api_response: dict,
+    dandiset_to_replace=None,
+    skip_existing_names=True,
 ):
     if skip_existing_names:
         # Check if dandiset with this name already exists. If it does, skip it.
@@ -80,12 +104,15 @@ def import_dandiset_from_response(
 def import_dandisets_from_response(api_url: str, dandiset_api_response: dict):
     """Import dandisets given a response from /api/dandisets/."""
     for result in dandiset_api_response['results']:
-        import_dandiset_from_response(api_url, result)
+        import_dandiset_from_response(api_url, result, skip_existing_names=False)
 
     # Handle API pagination
     if dandiset_api_response.get('next'):
         new_dandisets = requests.get(dandiset_api_response.get('next')).json()
-        import_dandisets_from_response(api_url, new_dandisets)
+        import_dandisets_from_response(
+            api_url,
+            new_dandisets,
+        )
 
 
 @click.command()
@@ -93,18 +120,27 @@ def import_dandisets_from_response(api_url: str, dandiset_api_response: dict):
 @click.option('--all', is_flag=True, required=False, help='Download all dandisets.')
 @click.option('--identifier', required=False, help='The identifier of the dandiset to import.')
 @click.option('--replace', default=None, help='The dandiset to replace with the imported one.')
-def import_dandisets(api_url: str, all: bool, identifier: str, replace: str):
+@click.option('--offset', default=0, help="Offset to add to each new dandiset's identifier.")
+@transaction.atomic
+def import_dandisets(api_url: str, all: bool, identifier: str, replace: str, offset=0):
+    original_sequence_value = get_sequence_value()
+    set_sequence_value(original_sequence_value + offset)
     if all:
         click.echo(f'Importing all dandisets from dandi-api deployment at {api_url}')
         dandisets = requests.get(urljoin(api_url, '/api/dandisets/')).json()
         import_dandisets_from_response(api_url, dandisets)
+        set_sequence_value(original_sequence_value)
 
     elif identifier:
         click.echo(f'Importing dandiset {identifier} from dandi-api deployment at {api_url}')
         dandiset = requests.get(urljoin(api_url, f'/api/dandisets/{identifier}/')).json()
         import_dandiset_from_response(
-            api_url, dandiset, dandiset_to_replace=replace, skip_existing_names=False
+            api_url,
+            dandiset,
+            dandiset_to_replace=replace,
+            skip_existing_names=False,
         )
+        set_sequence_value(original_sequence_value)
 
     else:
         click.echo(

--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -102,7 +102,9 @@ def import_dandisets(api_url: str, all: bool, identifier: str, replace: str):
     elif identifier:
         click.echo(f'Importing dandiset {identifier} from dandi-api deployment at {api_url}')
         dandiset = requests.get(urljoin(api_url, f'/api/dandisets/{identifier}/')).json()
-        import_dandiset_from_response(api_url, dandiset, dandiset_to_replace=replace, skip_existing_names=False)
+        import_dandiset_from_response(
+            api_url, dandiset, dandiset_to_replace=replace, skip_existing_names=False
+        )
 
     else:
         click.echo(

--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -43,7 +43,7 @@ def import_dandiset_from_response(api_url: str, dandiset_api_response: dict):
     # I can't think of a better way to uniquely identify dandisets
     # without being able to use identifiers.
     existing_dandiset = Version.objects.filter(name=dandiset_api_response['draft_version']['name'])
-    if existing_dandiset.first():
+    if existing_dandiset.exists():
         identifier = existing_dandiset.first().dandiset.identifier
         click.echo(
             f'Skipping {dandiset_api_response["draft_version"]["name"]} - dandiset {identifier} already exists with that name.'  # noqa: E501

--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -102,7 +102,7 @@ def import_dandisets(api_url: str, all: bool, identifier: str, replace: str):
     elif identifier:
         click.echo(f'Importing dandiset {identifier} from dandi-api deployment at {api_url}')
         dandiset = requests.get(urljoin(api_url, f'/api/dandisets/{identifier}/')).json()
-        import_dandiset_from_response(api_url, dandiset, replace, False)
+        import_dandiset_from_response(api_url, dandiset, dandiset_to_replace=replace, skip_existing_names=False)
 
     else:
         click.echo(

--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -1,8 +1,8 @@
-import requests
 from urllib.parse import urljoin
 
 from django.db import transaction
 import djclick as click
+import requests
 
 from dandiapi.api.models import Dandiset, Version
 
@@ -45,7 +45,7 @@ def import_dandisets_from_response(api_url: str, dandiset_api_response: dict):
         # Check if dandiset with this name already exists. If it does, skip it.
         # I can't think of a better way to uniquely identify dandisets
         # without being able to use identifiers.
-        existing_dandiset = Version.objects.filter(name=result["draft_version"]["name"])
+        existing_dandiset = Version.objects.filter(name=result['draft_version']['name'])
         if existing_dandiset.first():
             identifier = existing_dandiset.first().dandiset.identifier
             click.echo(
@@ -53,7 +53,7 @@ def import_dandisets_from_response(api_url: str, dandiset_api_response: dict):
             )
             continue
 
-        identifier = result["identifier"]
+        identifier = result['identifier']
         dandiset = Dandiset()
         dandiset.save()
 

--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -38,33 +38,37 @@ def import_versions_from_response(api_url: str, version_api_response: dict, dand
 
 
 @transaction.atomic
+def import_dandiset_from_response(api_url: str, dandiset_api_response: dict):
+    # Check if dandiset with this name already exists. If it does, skip it.
+    # I can't think of a better way to uniquely identify dandisets
+    # without being able to use identifiers.
+    existing_dandiset = Version.objects.filter(name=dandiset_api_response['draft_version']['name'])
+    if existing_dandiset.first():
+        identifier = existing_dandiset.first().dandiset.identifier
+        click.echo(
+            f'Skipping {dandiset_api_response["draft_version"]["name"]} - dandiset {identifier} already exists with that name.'  # noqa: E501
+        )
+        return
+
+    identifier = dandiset_api_response['identifier']
+    dandiset = Dandiset()
+    dandiset.save()
+
+    # get all versions associated with this dandiset
+    versions = requests.get(urljoin(api_url, f'/api/dandisets/{identifier}/versions/')).json()
+
+    click.echo(
+        f'Importing dandiset {identifier} "{dandiset_api_response["draft_version"]["name"]}" as dandiset {dandiset.identifier}'  # noqa: E501
+    )
+
+    import_versions_from_response(api_url, versions, dandiset)
+
+
+@transaction.atomic
 def import_dandisets_from_response(api_url: str, dandiset_api_response: dict):
     """Import dandisets given a response from /api/dandisets/."""
     for result in dandiset_api_response['results']:
-
-        # Check if dandiset with this name already exists. If it does, skip it.
-        # I can't think of a better way to uniquely identify dandisets
-        # without being able to use identifiers.
-        existing_dandiset = Version.objects.filter(name=result['draft_version']['name'])
-        if existing_dandiset.first():
-            identifier = existing_dandiset.first().dandiset.identifier
-            click.echo(
-                f'Skipping {result["draft_version"]["name"]} - dandiset {identifier} already exists with that name.'  # noqa: E501
-            )
-            continue
-
-        identifier = result['identifier']
-        dandiset = Dandiset()
-        dandiset.save()
-
-        # get all versions associated with this dandiset
-        versions = requests.get(urljoin(api_url, f'/api/dandisets/{identifier}/versions/')).json()
-
-        click.echo(
-            f'Importing dandiset {identifier} "{result["draft_version"]["name"]}" as dandiset {dandiset.identifier}'  # noqa: E501
-        )
-
-        import_versions_from_response(api_url, versions, dandiset)
+        import_dandiset_from_response(api_url, result)
 
     # Handle API pagination
     if dandiset_api_response.get('next'):
@@ -78,5 +82,4 @@ def import_dandisets(api_url: str):
     click.echo(f'Importing all dandisets from dandi-api deployment at {api_url}')
 
     dandisets = requests.get(urljoin(api_url, '/api/dandisets/')).json()
-
     import_dandisets_from_response(api_url, dandisets)

--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -1,0 +1,82 @@
+import requests
+from urllib.parse import urljoin
+
+from django.db import transaction
+import djclick as click
+
+from dandiapi.api.models import Dandiset, Version
+
+
+@transaction.atomic
+def import_versions_from_response(api_url: str, version_api_response: dict, dandiset: Dandiset):
+    """Import versions given a response from /api/dandisets/{identifier}/versions/."""
+    for result in version_api_response['results']:
+        # get the metadata of this version
+        metadata = requests.get(
+            urljoin(
+                api_url,
+                f'/api/dandisets/{result["dandiset"]["identifier"]}/versions/{result["version"]}/',
+            )
+        ).json()
+
+        click.echo(f'  Importing version "{result["version"]}"')
+
+        version = Version(
+            dandiset=dandiset,
+            name=result['name'],
+            version=result['version'],
+            doi=result.get('doi'),
+            status=result['status'],
+            metadata=metadata,
+        )
+        version.save()
+
+    # Handle API pagination
+    if version_api_response.get('next'):
+        next_versions = requests.get(version_api_response.get('next')).json()
+        import_versions_from_response(api_url, next_versions, dandiset)
+
+
+@transaction.atomic
+def import_dandisets_from_response(api_url: str, dandiset_api_response: dict):
+    """Import dandisets given a response from /api/dandisets/."""
+    for result in dandiset_api_response['results']:
+
+        # Check if dandiset with this name already exists. If it does, skip it.
+        # I can't think of a better way to uniquely identify dandisets
+        # without being able to use identifiers.
+        existing_dandiset = Version.objects.filter(name=result["draft_version"]["name"])
+        if existing_dandiset.first():
+            identifier = existing_dandiset.first().dandiset.identifier
+            click.echo(
+                f'Skipping {result["draft_version"]["name"]} - dandiset {identifier} already exists with that name.'  # noqa: E501
+            )
+            continue
+
+        identifier = result["identifier"]
+        dandiset = Dandiset()
+        dandiset.save()
+
+        # get all versions associated with this dandiset
+        versions = requests.get(urljoin(api_url, f'/api/dandisets/{identifier}/versions/')).json()
+
+        click.echo(
+            f'Importing dandiset {identifier} "{result["draft_version"]["name"]}" as dandiset {dandiset.identifier}'  # noqa: E501
+        )
+
+        import_versions_from_response(api_url, versions, dandiset)
+
+    # Handle API pagination
+    if dandiset_api_response.get('next'):
+        new_dandisets = requests.get(dandiset_api_response.get('next')).json()
+        import_dandisets_from_response(api_url, new_dandisets)
+
+
+@click.command()
+@click.argument('api_url')
+def import_dandisets(api_url: str):
+    click.echo(f'Importing all dandisets from dandi-api deployment at {api_url}')
+
+    dandisets = requests.get(urljoin(api_url, '/api/dandisets/')).json()
+
+    import_dandisets_from_response(api_url, dandisets)


### PR DESCRIPTION
Closes #516. This management script can be used to copy dandisets from any deployment of dandi-api into the environment it's being run from.