### PR TITLE
Add environment setting for Celery concurrency

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -75,6 +75,10 @@ class DandiMixin(ConfigMixin):
         'DEFAULT_AUTO_SCHEMA_CLASS': 'dandiapi.swagger.DANDISwaggerAutoSchema',
     }
 
+    # Some tasks working with lots of data need lots of memory, so we need to artificially lower
+    # the number of concurrent tasks (default is 8) to keep memory usage down.
+    CELERY_WORKER_CONCURRENCY = values.IntegerValue(environ=True, default=8)
+
 
 class DevelopmentConfiguration(DandiMixin, DevelopmentBaseConfiguration):
     # This makes pydantic model schema allow URLs with localhost in them.
@@ -106,7 +110,3 @@ class HerokuProductionConfiguration(DandiMixin, HerokuProductionBaseConfiguratio
 # the API server is running in (production/local or staging).
 class HerokuStagingConfiguration(HerokuProductionConfiguration):
     OAUTH2_PROVIDER_APPLICATION_MODEL = 'api.StagingApplication'
-
-    # We are using cheaper Heroku dynos for staging, so we need to artificially lower the number
-    # of concurrent tasks (default is 8) to keep memory usage down.
-    CELERY_WORKER_CONCURRENCY = 2

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'dandischema>=0.3.4',
+        'dandischema==0.3.4',
         'django>=3.1.2',
         'django-admin-display',
         'django-allauth',


### PR DESCRIPTION
Some tasks are too memory intensive for celery, so having a setting is
useful for tuning staging/production without releasing a new version.

Requires https://github.com/dandi/dandi-infrastructure/pull/98