### PR TITLE
Add separate dyno for celery beat

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,7 +1,4 @@
 release: ./manage.py migrate
 web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi
-# We are using the -B flag to launch the beat scheduler within the worker thread
-# This means that we cannot have multiple workers, as they would all trigger beat events
-# The alternative would be a separate worker to drive the beat, which is costly at our current Heroku dyno tier
 worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO
 celery-beat: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery beat --loglevel INFO

--- a/Procfile
+++ b/Procfile
@@ -3,4 +3,5 @@ web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi
 # We are using the -B flag to launch the beat scheduler within the worker thread
 # This means that we cannot have multiple workers, as they would all trigger beat events
 # The alternative would be a separate worker to drive the beat, which is costly at our current Heroku dyno tier
-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -B
+worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO
+celery-beat: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery beat --loglevel INFO


### PR DESCRIPTION
This lets us scale the number of workers without inadvertently firing multiple beat events.

The downside is that we need a separate dyno just to run chron, but such is life.