### PR TITLE
Optimize celery tasks

### DIFF
--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -5,7 +5,6 @@ import djclick as click
 import requests
 
 from dandiapi.api.models import Dandiset, Version
-from dandiapi.api.tasks import validate_version_metadata
 
 
 @transaction.atomic

--- a/dandiapi/api/management/commands/import_dandisets.py
+++ b/dandiapi/api/management/commands/import_dandisets.py
@@ -27,13 +27,10 @@ def import_versions_from_response(api_url: str, version_api_response: dict, dand
             name=result['name'],
             version=result['version'],
             doi=result.get('doi'),
-            status=result['status'],
+            status=Version.Status.PENDING,
             metadata=metadata,
         )
         version.save()
-
-        # validate the metadata after the transaction is commmited
-        transaction.on_commit(lambda: validate_version_metadata.delay(version.id))
 
     # Handle API pagination
     if version_api_response.get('next'):

--- a/dandiapi/api/management/commands/migrate_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_version_metadata.py
@@ -3,7 +3,6 @@ from django.conf import settings
 import djclick as click
 
 from dandiapi.api.models import Version
-from dandiapi.api.tasks import validate_version_metadata
 
 
 @click.command()

--- a/dandiapi/api/management/commands/migrate_version_metadata.py
+++ b/dandiapi/api/management/commands/migrate_version_metadata.py
@@ -25,7 +25,7 @@ def migrate_version_metadata(to_version: str):
             print(e)
             continue
 
-        version.metadata = metanew
-        version.save()
-
-        validate_version_metadata.delay(version.id)
+        if version.metadata != metanew:
+            version.metadata = metanew
+            version.status = Version.Status.PENDING
+            version.save()

--- a/dandiapi/api/scheduled_tasks.py
+++ b/dandiapi/api/scheduled_tasks.py
@@ -3,10 +3,11 @@ Define and register any scheduled celery tasks.
 
 This module is imported from celery.py in a post-app-load hook.
 """
+from datetime import timedelta
 
 from celery import shared_task
-from celery.schedules import crontab
 from celery.utils.log import get_task_logger
+from django.conf import settings
 from django.db.transaction import atomic
 
 from dandiapi.api.models import Version
@@ -35,4 +36,7 @@ def validate_draft_version_metadata():
 def register_scheduled_tasks(sender, **kwargs):
     """Register tasks with a celery beat schedule."""
     # Check for any draft versions that need validation every minute
-    sender.add_periodic_task(crontab(), validate_draft_version_metadata.s())
+    sender.add_periodic_task(
+        timedelta(seconds=settings.DANDI_VALIDATION_JOB_INTERVAL),
+        validate_draft_version_metadata.s(),
+    )

--- a/dandiapi/api/scheduled_tasks.py
+++ b/dandiapi/api/scheduled_tasks.py
@@ -17,17 +17,6 @@ logger = get_task_logger(__name__)
 
 @shared_task
 @atomic
-def write_draft_manifest_files():
-    logger.info('Writing manifest files for all draft versions')
-    # TODO Optimize this if it causes too much load in production.
-    # Rewriting every draft manifest every time is guaranteed not to miss any changes,
-    # so just do that for now to avoid the complexity involved with modification dates.
-    for draft_version in Version.objects.filter(version='draft').all():
-        write_manifest_files.delay(draft_version.id)
-
-
-@shared_task
-@atomic
 def validate_draft_version_metadata():
     logger.info('Checking for draft versions that need validation')
     # Select only the id of draft versions that have status PENDING
@@ -38,11 +27,12 @@ def validate_draft_version_metadata():
     for draft_version in pending_draft_versions:
         validate_version_metadata.delay(draft_version['id'])
 
+        # Revalidation should be triggered every time a version is modified,
+        # so now is a good time to write out the manifests as well.
+        write_manifest_files.delay(draft_version.id)
+
 
 def register_scheduled_tasks(sender, **kwargs):
     """Register tasks with a celery beat schedule."""
-    # Write out all draft manifests every day at 1 AM
-    sender.add_periodic_task(crontab(hour=1), write_draft_manifest_files.s())
-
     # Check for any draft versions that need validation every 2 minutes
     sender.add_periodic_task(crontab(minute='*/2'), validate_draft_version_metadata.s())

--- a/dandiapi/api/scheduled_tasks.py
+++ b/dandiapi/api/scheduled_tasks.py
@@ -10,7 +10,7 @@ from celery.utils.log import get_task_logger
 from django.db.transaction import atomic
 
 from dandiapi.api.models import Version
-from dandiapi.api.tasks import write_manifest_files, validate_version_metadata
+from dandiapi.api.tasks import validate_version_metadata, write_manifest_files
 
 logger = get_task_logger(__name__)
 

--- a/dandiapi/api/scheduled_tasks.py
+++ b/dandiapi/api/scheduled_tasks.py
@@ -34,5 +34,5 @@ def validate_draft_version_metadata():
 
 def register_scheduled_tasks(sender, **kwargs):
     """Register tasks with a celery beat schedule."""
-    # Check for any draft versions that need validation every 2 minutes
-    sender.add_periodic_task(crontab(minute='*/2'), validate_draft_version_metadata.s())
+    # Check for any draft versions that need validation every minute
+    sender.add_periodic_task(crontab(), validate_draft_version_metadata.s())

--- a/dandiapi/api/scheduled_tasks.py
+++ b/dandiapi/api/scheduled_tasks.py
@@ -10,7 +10,7 @@ from celery.utils.log import get_task_logger
 from django.db.transaction import atomic
 
 from dandiapi.api.models import Version
-from dandiapi.api.tasks import write_manifest_files
+from dandiapi.api.tasks import write_manifest_files, validate_version_metadata
 
 logger = get_task_logger(__name__)
 
@@ -26,7 +26,23 @@ def write_draft_manifest_files():
         write_manifest_files.delay(draft_version.id)
 
 
+@shared_task
+@atomic
+def validate_draft_version_metadata():
+    logger.info('Checking for draft versions that need validation')
+    # Select only the id of draft versions that have status PENDING
+    pending_draft_versions = (
+        Version.objects.filter(status=Version.Status.PENDING).filter(version='draft').values('id')
+    )
+    logger.info('Found %s versions to validate', pending_draft_versions.count())
+    for draft_version in pending_draft_versions:
+        validate_version_metadata.delay(draft_version['id'])
+
+
 def register_scheduled_tasks(sender, **kwargs):
     """Register tasks with a celery beat schedule."""
     # Write out all draft manifests every day at 1 AM
     sender.add_periodic_task(crontab(hour=1), write_draft_manifest_files.s())
+
+    # Check for any draft versions that need validation every 2 minutes
+    sender.add_periodic_task(crontab(minute='*/2'), validate_draft_version_metadata.s())

--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -48,7 +48,8 @@ def calculate_sha256(blob_id: int) -> None:
 
     # The newly calculated sha256 digest will be included in the metadata, so we need to revalidate
     for asset in asset_blob.assets.all():
-        validate_asset_metadata.delay(asset.id)
+        # validate_asset_metadata runs very quickly, no need to delay it
+        validate_asset_metadata(asset.id)
 
 
 @shared_task

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -300,6 +300,9 @@ def test_asset_create(api_client, user, draft_version, asset_blob):
     end_time = draft_version.modified
     assert start_time < end_time
 
+    # Adding an Asset should trigger a revalidation
+    assert draft_version.status == Version.Status.PENDING
+
 
 @pytest.mark.django_db
 def test_asset_create_no_valid_blob(api_client, user, draft_version):
@@ -444,6 +447,9 @@ def test_asset_rest_update(api_client, user, draft_version, asset, asset_blob):
     end_time = draft_version.modified
     assert start_time < end_time
 
+    # Updating an Asset should trigger a revalidation
+    assert draft_version.status == Version.Status.PENDING
+
 
 @pytest.mark.django_db
 def test_asset_rest_update_unauthorized(api_client, draft_version, asset):
@@ -536,6 +542,9 @@ def test_asset_rest_delete(api_client, user, draft_version, asset):
     draft_version.refresh_from_db()
     end_time = draft_version.modified
     assert start_time < end_time
+
+    # Deleting an Asset should trigger a revalidation
+    assert draft_version.status == Version.Status.PENDING
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from guardian.shortcuts import assign_perm
 import pytest
 
-from dandiapi.api.models import Dandiset
+from dandiapi.api.models import Dandiset, Version
 
 from .fuzzy import DANDISET_ID_RE, DANDISET_SCHEMA_ID_RE, TIMESTAMP_RE, UTC_ISO_TIMESTAMP_RE
 
@@ -225,6 +225,7 @@ def test_dandiset_rest_create(api_client, user):
     assert dandiset.most_recent_published_version is None
     assert dandiset.draft_version.version == 'draft'
     assert dandiset.draft_version.name == name
+    assert dandiset.draft_version.status == Version.Status.PENDING
 
     # Verify that computed metadata was injected
     year = datetime.now().year
@@ -311,6 +312,7 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
     assert dandiset.most_recent_published_version is None
     assert dandiset.draft_version.version == 'draft'
     assert dandiset.draft_version.name == name
+    assert dandiset.draft_version.status == Version.Status.PENDING
 
     # Verify that computed metadata was injected
     year = datetime.now().year
@@ -411,6 +413,7 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
     assert dandiset.most_recent_published_version is None
     assert dandiset.draft_version.version == 'draft'
     assert dandiset.draft_version.name == name
+    assert dandiset.draft_version.status == Version.Status.PENDING
 
     # Verify that computed metadata was injected
     year = datetime.now().year

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -503,6 +503,7 @@ def test_version_rest_update(api_client, user, draft_version):
 
     assert draft_version.metadata == saved_metadata
     assert draft_version.name == new_name
+    assert draft_version.status == Version.Status.PENDING
 
 
 @pytest.mark.django_db
@@ -572,6 +573,7 @@ def test_version_rest_update_large(api_client, user, draft_version):
     draft_version.refresh_from_db()
     assert draft_version.metadata == saved_metadata
     assert draft_version.name == new_name
+    assert draft_version.status == Version.Status.PENDING
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -207,10 +207,11 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         # Trigger a version metadata validation, as saving the version might change the metadata
         validate_version_metadata.delay(version.id)
 
-        # Trigger an asset metadata validation
+        # Trigger an asset metadata validation immediately
         # This will fail if the digest hasn't been calculated yet, but we still need to try now
         # just in case we are using an existing blob that has already computed its digest.
-        validate_asset_metadata.delay(asset.id)
+        # We do not bother to delay it because it should run very quickly.
+        validate_asset_metadata(asset.id)
 
         serializer = AssetDetailSerializer(instance=asset)
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -290,7 +291,8 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         # Trigger an asset metadata validation
         # This will fail if the digest hasn't been calculated yet, but we still need to try now
         # just in case we are using an existing blob that has already computed its digest.
-        validate_asset_metadata.delay(new_asset.id)
+        # We do not bother to delay it because it should run very quickly.
+        validate_asset_metadata(new_asset.id)
 
         serializer = AssetDetailSerializer(instance=new_asset)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -26,7 +26,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSetMixin
 
 from dandiapi.api.models import Asset, AssetBlob, Dandiset, Version
-from dandiapi.api.tasks import validate_asset_metadata, validate_version_metadata
+from dandiapi.api.tasks import validate_asset_metadata
 from dandiapi.api.views.common import (
     ASSET_ID_PARAM,
     PATH_PREFIX_PARAM,

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -201,11 +201,10 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         asset.save()
         version.assets.add(asset)
 
+        # Trigger a version metadata validation, as saving the version might change the metadata
+        version.status = Version.Status.PENDING
         # Save the version so that the modified field is updated
         version.save()
-
-        # Trigger a version metadata validation, as saving the version might change the metadata
-        validate_version_metadata.delay(version.id)
 
         # Trigger an asset metadata validation immediately
         # This will fail if the digest hasn't been calculated yet, but we still need to try now
@@ -282,11 +281,10 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
                 version.assets.add(new_asset)
                 version.assets.remove(old_asset)
 
+        # Trigger a version metadata validation, as saving the version might change the metadata
+        version.status = Version.Status.PENDING
         # Save the version so that the modified field is updated
         version.save()
-
-        # Trigger a version metadata validation, as saving the version might change the metadata
-        validate_version_metadata.delay(version.id)
 
         # Trigger an asset metadata validation
         # This will fail if the digest hasn't been calculated yet, but we still need to try now
@@ -321,11 +319,10 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
 
         version.assets.remove(asset)
 
+        # Trigger a version metadata validation, as saving the version might change the metadata
+        version.status = Version.Status.PENDING
         # Save the version so that the modified field is updated
         version.save()
-
-        # Trigger a version metadata validation, as saving the version might change the metadata
-        validate_version_metadata.delay(version.id)
 
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -22,7 +22,6 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from dandiapi.api.mail import send_ownership_change_emails
 from dandiapi.api.models import Dandiset, Version
-from dandiapi.api.tasks import validate_version_metadata
 from dandiapi.api.views.common import DANDISET_PK_PARAM, DandiPagination
 from dandiapi.api.views.serializers import (
     DandisetDetailSerializer,

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -171,10 +171,14 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         assign_perm('owner', request.user, dandiset)
 
         # Create new draft version
-        version = Version(dandiset=dandiset, name=name, metadata=metadata, version='draft')
+        version = Version(
+            dandiset=dandiset,
+            name=name,
+            metadata=metadata,
+            version='draft',
+            status=Version.Status.PENDING,
+        )
         version.save()
-
-        validate_version_metadata.delay(version.id)
 
         serializer = DandisetDetailSerializer(instance=dandiset)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -10,7 +10,7 @@ from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSe
 
 from dandiapi.api import doi
 from dandiapi.api.models import Dandiset, Version
-from dandiapi.api.tasks import delete_doi_task, validate_version_metadata, write_manifest_files
+from dandiapi.api.tasks import delete_doi_task, write_manifest_files
 from dandiapi.api.views.common import DANDISET_PK_PARAM, VERSION_PARAM, DandiPagination
 from dandiapi.api.views.serializers import (
     VersionDetailSerializer,

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -82,9 +82,8 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
         version.name = name
         version.metadata = metadata
+        version.status = Version.Status.PENDING
         version.save()
-
-        validate_version_metadata.delay(version.id)
 
         serializer = VersionDetailSerializer(instance=version)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -61,6 +61,8 @@ class DandiMixin(ConfigMixin):
     DANDI_DOI_API_PREFIX = values.Value(environ=True)
     DANDI_DOI_PUBLISH = values.BooleanValue(environ=True, default=False)
 
+    DANDI_VALIDATION_JOB_INTERVAL = values.IntegerValue(environ=True, default=60)
+
     # The CloudAMQP connection was dying, using the heartbeat should keep it alive
     CELERY_BROKER_HEARTBEAT = 20
 


### PR DESCRIPTION
* `validate_asset_metadata` has proven to be consistently very quick, so we can simply do it in band and save the overhead of dispatching a task.
* Instead of revalidating Versions every time they are modified in any way (including adding, updating, removing Assets in the Version), we have a scheduled task that checks for any draft Versions with status `PENDING` and validates them then. This effectively debounces Version validation.
* Since we want to revalidate draft Versions basically any time they are changed, that is also a good time to dispatch the draft manifest task, which means we can do away with the 1:00 AM scheduled job and the associated inefficiencies.

This should also fix https://github.com/dandi/dandi-api/issues/537