### PR TITLE
Fix optimize tasks

### DIFF
--- a/dandiapi/api/scheduled_tasks.py
+++ b/dandiapi/api/scheduled_tasks.py
@@ -30,7 +30,7 @@ def validate_draft_version_metadata():
 
         # Revalidation should be triggered every time a version is modified,
         # so now is a good time to write out the manifests as well.
-        write_manifest_files.delay(draft_version.id)
+        write_manifest_files.delay(draft_version['id'])
 
 
 def register_scheduled_tasks(sender, **kwargs):

--- a/dandiapi/api/scheduled_tasks.py
+++ b/dandiapi/api/scheduled_tasks.py
@@ -19,18 +19,18 @@ logger = get_task_logger(__name__)
 @shared_task
 @atomic
 def validate_draft_version_metadata():
-    logger.info('Checking for draft versions that need validation')
     # Select only the id of draft versions that have status PENDING
     pending_draft_versions = (
         Version.objects.filter(status=Version.Status.PENDING).filter(version='draft').values('id')
     )
-    logger.info('Found %s versions to validate', pending_draft_versions.count())
-    for draft_version in pending_draft_versions:
-        validate_version_metadata.delay(draft_version['id'])
+    if pending_draft_versions.count() > 0:
+        logger.info('Found %s versions to validate', pending_draft_versions.count())
+        for draft_version in pending_draft_versions:
+            validate_version_metadata.delay(draft_version['id'])
 
-        # Revalidation should be triggered every time a version is modified,
-        # so now is a good time to write out the manifests as well.
-        write_manifest_files.delay(draft_version['id'])
+            # Revalidation should be triggered every time a version is modified,
+            # so now is a good time to write out the manifests as well.
+            write_manifest_files.delay(draft_version['id'])
 
 
 def register_scheduled_tasks(sender, **kwargs):


### PR DESCRIPTION
* We were using `draft_version.id` instead of `draft_version['id']` to dispatch the draft manifest writing task
* The scheduled job triggers frequently and most often finds nothing to do, so remove extraneous log messages to reduce log spam.