### PR TITLE
Paginate asset paths endpoint

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -62,9 +62,9 @@ def test_asset_rest_path(
 
     # Do folder assertions
     for folder_path in expected['folders']:
-        assert folder_path in paths['folders']
+        assert folder_path in paths['results']['folders']
 
-        folder_entry = paths['folders'][folder_path]
+        folder_entry = paths['results']['folders'][folder_path]
         folder_assets = list(
             Asset.objects.all().filter(path__startswith=f'{query_prefix}{folder_path}')
         )
@@ -81,10 +81,10 @@ def test_asset_rest_path(
 
     # Do file assertions
     for file_path in expected['files']:
-        assert file_path in paths['files']
+        assert file_path in paths['results']['files']
 
         asset: Asset = Asset.objects.get(path=f'{query_prefix}{file_path}')
-        assert paths['files'][file_path] == AssetSerializer(asset).data
+        assert paths['results']['files'][file_path] == AssetSerializer(asset).data
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -353,7 +353,9 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         (to refer to the root folder) must be the empty string.
         """
         path_prefix: str = self.request.query_params.get('path_prefix') or ''
-        qs = self.get_queryset().select_related('blob').filter(path__startswith=path_prefix)
+        qs = self.paginate_queryset(
+            self.get_queryset().select_related('blob').filter(path__startswith=path_prefix)
+        )
 
         folders = {}
         files = {}
@@ -385,6 +387,6 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
                     entry['modified'] = max(entry['modified'], asset.modified)  # latest
 
         paths = AssetPathsSerializer({'folders': folders, 'files': files})
-        return Response(paths.data)
+        return self.get_paginated_response(paths.data)
 
     # TODO: add create to forge an asset from a validation


### PR DESCRIPTION
Adds pagination to the asset paths endpoint. Will unblock https://github.com/dandi/dandiarchive/pull/919.