### PR TITLE
Checksum queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,10 @@
 release: ./manage.py migrate
 web: gunicorn --bind 0.0.0.0:$PORT dandiapi.wsgi
-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO
-celery-beat: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery beat --loglevel INFO
+# celery-beat: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery beat --loglevel INFO
+# Rather than using a dedicated worker for Celery Beat, we simply use the -B option on the priority task worker.
+# This means that we cannot safely scale up the number of priority-workers without Celery Beat triggering multiple events.
+# This is OK for now because of how lightweight all high priority tasks currently are,
+# but we may need to switch back to a dedicated worker in the future.
+# The queue `celery` is the default queue. Right now the only named queue is `calculate_sha256`.
+priority-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q celery -B
+checksum-worker: REMAP_SIGTERM=SIGQUIT celery --app dandiapi.celery worker --loglevel INFO -Q calculate_sha256

--- a/dandiapi/api/tasks.py
+++ b/dandiapi/api/tasks.py
@@ -30,7 +30,7 @@ from dandischema.metadata import validate
 logger = get_task_logger(__name__)
 
 
-@shared_task
+@shared_task(queue='calculate_sha256')
 @atomic
 def calculate_sha256(blob_id: int) -> None:
     logger.info('Starting sha256 calculation for blob %s', blob_id)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,6 +27,7 @@ services:
       "worker",
       "--loglevel", "INFO",
       "--without-heartbeat",
+      "-Q", "celery,calculate_sha256",
       "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors


### PR DESCRIPTION
* SHA256 calculations now go to their own queue, `calculate_sha256`. Every other task still goes to the default queue, `celery`.
* The dev environment still pulls from both queues.
* In production there is one worker that handles checksums only, and one worker that handles every other task + running celery beat. The only tasks that eat up worker time are checksums, so we can now scale that separately without having to worry about scaling the high priority worker.

Fixes #542 

dandi-cli tests will break until https://github.com/dandi/dandi-cli/pull/787