### PR TITLE
Expose port for RabbitMQ management console

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     image: rabbitmq:management
     ports:
       - ${DOCKER_RABBITMQ_PORT-5672}:5672
+      - ${DOCKER_RABBITMQ_CONSOLE_PORT-15672}:15672
 
   minio:
     image: minio/minio:latest


### PR DESCRIPTION
This lets you view the RabbitMQ management console GUI when running RabbitMQ locally in Docker (just like the one in CloudAMQP).