### PR TITLE
Pin flake8<4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
-    flake8
+    flake8<4
     flake8-black
     flake8-bugbear
     flake8-docstrings


### PR DESCRIPTION
There is currently an incompatibility between the latest flake8 version
and the latest flake8-isort:
https://github.com/gforcada/flake8-isort/issues/103

We could pin flake8-isort instead, but apparently pip gets cranky when
trying to resolve dependencies, so for now we simply pin flake8<4.

This should resolve the CI grumpiness we've been seeing.