### PR TITLE
Always add schemakey

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -248,6 +248,8 @@ def test_dandiset_rest_create(api_client, user):
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
         'schemaKey': 'Dandiset',
+        'access': [{'schemaKey': 'AccessRequirements', 'status': 'dandi:OpenAccess'}],
+        'repository': 'https://dandiarchive.org/',
         'contributor': [
             {
                 'name': 'Doe, John',
@@ -336,6 +338,8 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
         'schemaKey': 'Dandiset',
+        'access': [{'schemaKey': 'AccessRequirements', 'status': 'dandi:OpenAccess'}],
+        'repository': 'https://dandiarchive.org/',
         'contributor': [
             {
                 'name': 'Doe, John',
@@ -437,6 +441,8 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
         'schemaKey': 'Dandiset',
+        'access': [{'schemaKey': 'AccessRequirements', 'status': 'dandi:OpenAccess'}],
+        'repository': 'https://dandiarchive.org/',
         'contributor': [
             {
                 'name': 'Jane Doe',

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -247,6 +247,7 @@ def test_dandiset_rest_create(api_client, user):
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaKey': 'Dandiset',
         'contributor': [
             {
                 'name': 'Doe, John',
@@ -334,6 +335,7 @@ def test_dandiset_rest_create_with_identifier(api_client, admin_user):
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaKey': 'Dandiset',
         'contributor': [
             {
                 'name': 'Doe, John',
@@ -434,6 +436,7 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
         ),
         '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaKey': 'Dandiset',
         'contributor': [
             {
                 'name': 'Jane Doe',

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -118,6 +118,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         # Only inject a schemaVersion and default contributor field if they are
         # not specified in the metadata
         metadata = {
+            'schemaKey': 'Dandiset',
             'schemaVersion': settings.DANDI_SCHEMA_VERSION,
             'contributor': [
                 {

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -1,6 +1,7 @@
 import logging
 
 from allauth.socialaccount.models import SocialAccount
+from dandischema.models import Dandiset as PydanticDandiset
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
@@ -132,6 +133,9 @@ class DandisetViewSet(ReadOnlyModelViewSet):
             ],
             **metadata,
         }
+        # Run the metadata through the pydantic model to automatically include any boilerplate
+        # like the access or repository fields
+        metadata = PydanticDandiset.unvalidated(**metadata).json_dict()
 
         if 'identifier' in serializer.validated_data['metadata']:
             identifier = serializer.validated_data['metadata']['identifier']


### PR DESCRIPTION
* Include `schemaKey` in metadata when creating new dandiset
* Run the metadata through the pydantic model to ensure it has all preset fields

Fixes https://github.com/dandi/dandiarchive/issues/931