### PR TITLE
Fix failing tests when running tox with docker

### DIFF
--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import os
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -91,7 +90,7 @@ def test_published_version_metadata_computed(published_version: Version):
         **original_metadata,
         'manifestLocation': [
             (
-                f'http://{os.getenv("DJANGO_MINIO_STORAGE_ENDPOINT")}/test-dandiapi-dandisets'
+                f'http://{settings.MINIO_STORAGE_ENDPOINT}/test-dandiapi-dandisets'
                 f'/test-prefix/dandisets/{published_version.dandiset.identifier}'
                 f'/{published_version.version}/assets.yaml'
             )
@@ -297,7 +296,7 @@ def test_version_publish_version(draft_version, asset):
         'dateCreated': UTC_ISO_TIMESTAMP_RE,
         'datePublished': UTC_ISO_TIMESTAMP_RE,
         'manifestLocation': [
-            f'http://{os.getenv("DJANGO_MINIO_STORAGE_ENDPOINT")}/test-dandiapi-dandisets/test-prefix/dandisets/{publish_version.dandiset.identifier}/{publish_version.version}/assets.yaml',  # noqa: E501
+            f'http://{settings.MINIO_STORAGE_ENDPOINT}/test-dandiapi-dandisets/test-prefix/dandisets/{publish_version.dandiset.identifier}/{publish_version.version}/assets.yaml',  # noqa: E501
         ],
         'identifier': f'DANDI:{publish_version.dandiset.identifier}',
         'version': publish_version.version,
@@ -674,7 +673,7 @@ def test_version_rest_publish(api_client, user: User, draft_version: Version, as
         },
         'datePublished': UTC_ISO_TIMESTAMP_RE,
         'manifestLocation': [
-            f'http://{os.getenv("DJANGO_MINIO_STORAGE_ENDPOINT")}/test-dandiapi-dandisets/test-prefix/dandisets/{draft_version.dandiset.identifier}/{published_version.version}/assets.yaml',  # noqa: E501
+            f'http://{settings.MINIO_STORAGE_ENDPOINT}/test-dandiapi-dandisets/test-prefix/dandisets/{draft_version.dandiset.identifier}/{published_version.version}/assets.yaml',  # noqa: E501
         ],
         'identifier': f'DANDI:{draft_version.dandiset.identifier}',
         'version': published_version.version,

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -90,8 +91,9 @@ def test_published_version_metadata_computed(published_version: Version):
         **original_metadata,
         'manifestLocation': [
             (
-                f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/dandisets'
-                f'/{published_version.dandiset.identifier}/{published_version.version}/assets.yaml'
+                f'http://{os.getenv("DJANGO_MINIO_STORAGE_ENDPOINT")}/test-dandiapi-dandisets'
+                f'/test-prefix/dandisets/{published_version.dandiset.identifier}'
+                f'/{published_version.version}/assets.yaml'
             )
         ],
         'name': published_version.name,
@@ -295,7 +297,7 @@ def test_version_publish_version(draft_version, asset):
         'dateCreated': UTC_ISO_TIMESTAMP_RE,
         'datePublished': UTC_ISO_TIMESTAMP_RE,
         'manifestLocation': [
-            f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/dandisets/{publish_version.dandiset.identifier}/{publish_version.version}/assets.yaml',  # noqa: E501
+            f'http://{os.getenv("DJANGO_MINIO_STORAGE_ENDPOINT")}/test-dandiapi-dandisets/test-prefix/dandisets/{publish_version.dandiset.identifier}/{publish_version.version}/assets.yaml',  # noqa: E501
         ],
         'identifier': f'DANDI:{publish_version.dandiset.identifier}',
         'version': publish_version.version,
@@ -672,7 +674,7 @@ def test_version_rest_publish(api_client, user: User, draft_version: Version, as
         },
         'datePublished': UTC_ISO_TIMESTAMP_RE,
         'manifestLocation': [
-            f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/dandisets/{draft_version.dandiset.identifier}/{published_version.version}/assets.yaml',  # noqa: E501
+            f'http://{os.getenv("DJANGO_MINIO_STORAGE_ENDPOINT")}/test-dandiapi-dandisets/test-prefix/dandisets/{draft_version.dandiset.identifier}/{published_version.version}/assets.yaml',  # noqa: E501
         ],
         'identifier': f'DANDI:{draft_version.dandiset.identifier}',
         'version': published_version.version,


### PR DESCRIPTION
Some tests assume minio is running at `localhost:9000`, but this is only true when running tox natively. If running it via docker, minio will be running at `minio:9000`. To fix this, I had the tests retrieve the minio url from the `DJANGO_MINIO_STORAGE_ENDPOINT` environment variable.