### PR TITLE
Support requesting sorted assets (take 2)

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -109,7 +109,7 @@ class AssetFilter(filters.FilterSet):
 
 
 class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewSet):
-    queryset = Asset.objects.all()
+    queryset = Asset.objects.all().order_by('created')
 
     permission_classes = [IsAuthenticatedOrReadOnly]
     serializer_class = AssetSerializer
@@ -119,10 +119,8 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
     lookup_field = 'asset_id'
     lookup_value_regex = Asset.UUID_REGEX
 
-    filter_backends = [filters.OrderingFilter]
+    filter_backends = [filters.DjangoFilterBackend]
     filterset_class = AssetFilter
-    ordering_fields = ['created', 'modified', 'path']
-    ordering = ['created']
 
     @swagger_auto_schema(
         responses={

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -109,7 +109,7 @@ class AssetFilter(filters.FilterSet):
 
 
 class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewSet):
-    queryset = Asset.objects.all().order_by('created')
+    queryset = Asset.objects.all()
 
     permission_classes = [IsAuthenticatedOrReadOnly]
     serializer_class = AssetSerializer
@@ -119,8 +119,10 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
     lookup_field = 'asset_id'
     lookup_value_regex = Asset.UUID_REGEX
 
-    filter_backends = [filters.DjangoFilterBackend]
+    filter_backends = [filters.OrderingFilter]
     filterset_class = AssetFilter
+    ordering_fields = ['created', 'modified', 'path']
+    ordering = ['created']
 
     @swagger_auto_schema(
         responses={

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -102,6 +102,7 @@ class AssetRequestSerializer(serializers.Serializer):
 
 class AssetFilter(filters.FilterSet):
     path = filters.CharFilter(lookup_expr='istartswith')
+    order = filters.OrderingFilter(fields=['created', 'modified', 'path'])
 
     class Meta:
         model = Asset


### PR DESCRIPTION
This seems to be the standard way to implement this.  With this, sort order can be specified in API requests with the `ordering` query parameter, e.g., `ordering=created` (or `ordering=-created` for reverse order).

Closes #563.