### PR TITLE
3rd draft of zarr design doc

### DIFF
--- a/doc/design/zarr-support-3.md
+++ b/doc/design/zarr-support-3.md
@@ -21,9 +21,9 @@ The intended use of Zarr archives is primarily to support use cases where data a
 ## API endpoints
 * **POST /api/zarr/**
 
-  Create a new zarr archive.
+  Create a new zarr archive and mint a UUID for it which would become `zarr_id`
 
-  Returns a zarr ID
+  Returns the `zarr_id`
 
 * **GET /api/zarr/{zarr_id}/**
 
@@ -46,6 +46,7 @@ The intended use of Zarr archives is primarily to support use cases where data a
 
   Requires a list of file paths and ETags (md5 checksums).
   The number of files being uploaded must be less than some experimentally defined limit (say ~500).
+  If the limit is exceeded, return response 400.
   This limit should be chosen so that no upload requests can conceivably exceed the Heroku request timeout (30s).
   The file paths may include already uploaded files; this is how updates are done.
 

--- a/doc/design/zarr-support-3.md
+++ b/doc/design/zarr-support-3.md
@@ -73,7 +73,7 @@ The intended use of Zarr archives is primarily to support use cases where data a
   Return an asset ID
 
 When added to a dandiset, zarr archives will appear as a normal `Asset` in all the asset API endpoints.
-There will be a flag `zarr: true` indicating that the asset is a zarr archive.
+The asset metadata will contain the information required to determine if an asset is a normal file blob or a zarr file.
 
 ## Storage implementation
 A zarr archive with a `zarr_id` `c1223302-aff4-44aa-bd4b-952aed997c78` is stored in the public S3 bucket: `dandiarchive/zarr/c1223302-aff4-44aa-bd4b-952aed997c78/...`

--- a/doc/design/zarr-support-3.md
+++ b/doc/design/zarr-support-3.md
@@ -6,10 +6,6 @@ A tree hash is computed as the zarr archive is uploaded.
 Each node in the tree hash in the hash is stored in S3 to avoid bloating the DB.
 Zarr archives as a whole are too big to be copied.
 
-## Publishing support
-We have not yet finalized a plan for publishing zarr archives, so this design is a stopgap measure to support uploading in the meantime.
-Until the plan is finished and implemented, publishing dandisets with zarr archives will simply not be permitted.
-
 # Requirements
 1. Zarr archives are stored in a "directory" in S3.
 1. Each zarr archive corresponds to a single Asset.
@@ -18,7 +14,7 @@ Until the plan is finished and implemented, publishing dandisets with zarr archi
 1. The system can theoretically handle zarr files with ~1 million subfiles, each of size 64 * 64 * 64 bytes ~= 262 kilobytes.
 1. Zarr metadata must be mutable for zarr files in draft dandisets.
 1. Zarr archives must not be copied, as they are too large to reasonably store multiple copies.
-1. Publishing dandisets with zarr archives is not a requirement at this time.
+1. Zarr archives are immutable as long as they are contained by a published dandiset.
 
 # Implementation
 
@@ -142,8 +138,9 @@ Every update to a `.checksum` file also requires updating the `.checksum` of the
 This bubbles up to the top of the zarr archive, where the final `.checksum` for the entire archive can be found.
 
 # Publishing support
-Any dandiset that contains a zarr file cannot be published.
+After a dandiset that contains a zarr archive is published, that zarr archive is immutable.
+This ensures that published dandisets are truly immutable.
 
-The publish button will be disabled in the GUI with a notice to that effect.
+Immutability is enforced by disabled the upload and delete endpoints for the zarr archive.
 
-The CLI should also alert the user before they upload a zarr file to a dandiset that this will render the dandiset unpublishable.
+The client needs to agressively inform users that publishing a dandiset with a zarr archive will render that zarr archive immutable.

--- a/doc/design/zarr-support-3.md
+++ b/doc/design/zarr-support-3.md
@@ -4,7 +4,7 @@ Zarr archives are stored in their entirety in S3.
 Zarr archives are represented by a single Asset through the API.
 A tree hash is computed as the zarr archive is uploaded.
 Each node in the tree hash in the hash is stored in S3 to avoid bloating the DB.
-Zarr archives as a whole are too big to be copied.
+The intended use of Zarr archives is primarily to support use cases where data are too big to be copied. However, Zarr archives can be small as well.
 
 # Requirements
 1. Zarr archives are stored in a "directory" in S3.
@@ -78,7 +78,7 @@ There will be a flag `zarr: true` indicating that the asset is a zarr archive.
 ## Storage implementation
 A zarr archive with a `zarr_id` `c1223302-aff4-44aa-bd4b-952aed997c78` is stored in the public S3 bucket: `dandiarchive/zarr/c1223302-aff4-44aa-bd4b-952aed997c78/...`
 
-Paths for zarr files should never use a `/` prefix.
+Paths for zarr files, or any assets in the archive, should never use a `/` prefix.
 `foo/bar.txt` is correct, `/foo/bar.txt` is not.
 
 If a client uploaded a file `1/2/3/foo.bar`, it would be stored at `dandiarchive/zarr/c1223302-aff4-44aa-bd4b-952aed997c78/1/2/3/foo.bar`.

--- a/doc/design/zarr-support-3.md
+++ b/doc/design/zarr-support-3.md
@@ -33,6 +33,12 @@ Until the plan is finished and implemented, publishing dandisets with zarr archi
 
   Returns some information about the zarr archive, like name, S3 path+url, and checksum
 
+* **GET /api/zarr/{zarr_id}/{path}**
+
+  When the path exists in S3, returns some information about the zarr file, like name, S3 path+url, and checksum.
+  When the path is a directory in S3, returns a paginated list of files and directories. 
+  Returns 404 if the path is not present in S3.
+
 * **GET /api/zarr/{zarr_id}/upload/**
 
   Returns a 204 if an upload is in progress, or a 404 if an upload is not in progress.
@@ -64,9 +70,10 @@ Until the plan is finished and implemented, publishing dandisets with zarr archi
   Deletes zarr files from S3, and updates the tree hash accordingly.
   Requires a list of file paths
 
-* **POST /api/dandisets/{...}/versions/{...}/assets/zarr/{zarr_id}/**
+* **POST /api/dandisets/{...}/versions/{...}/assets/**
 
-  Creates a new Asset that points to the zarr archive.
+  Augments the existing endpoint to create a new Asset that points to the zarr archive.
+  Requires a `zarr_id` in the request body instead of a `blob_id`.
   Return an asset ID
 
 When added to a dandiset, zarr archives will appear as a normal `Asset` in all the asset API endpoints.

--- a/doc/design/zarr-support-3.md
+++ b/doc/design/zarr-support-3.md
@@ -126,20 +126,22 @@ The last `.checksum` contains the final tree hash for the entire zarr archive.
 Each zarr file and directory in the archive has a path and a checksum (`md5`).
 For files, this is simply the ETag.
 For directories, it is calculated like so:
-1. List all immediate children in JSON objects like `{"path": "foo/bar", "md5": "12345...67890"}`.
-1. Order that listing alphabetically by `path`.
+1. List all immediate child files and directories in JSON objects like `{"path":"foo/bar","md5":"12345...67890"}`.
+1. Create an object `{"files":[...],"directories":[...]}` containing those child objects, ordered alphabetically by `path`.
 1. Take the resulting JSON list, serialize it to a string, and take the MD5 hash of that string.
 
 For every directory in the zarr archive, the API server maintains a `.checksum` file which contains the checksum of the directory, and also the checksums of the directory contents for easier updates.
 The `.checksum` file is stored in JSON format, exactly like the format used to calculate the checksum:
 ```
-{"checksums": [{"path": "foo/bar", "md5": "12345...67890"}, ...], "md5": "09876...54321"}
+{"checksums":{"files":[{"path":"foo/bar","md5":"12345...67890"},...],"directories":[{"path":"foo/baz","md5":"abc...def"},...]},"md5":"09876...54321"}
 ```
 
 To update a `.checksum` file, the API server simply needs to read the existing contents, modify `checksums` to reflect the new state of the zarr archive, serialize and calculate the MD5, then save the new contents.
 
 Every update to a `.checksum` file also requires updating the `.checksum` of the parent directory, since the `md5` of the child has change.
 This bubbles up to the top of the zarr archive, where the final `.checksum` for the entire archive can be found.
+
+No spaces are used in JSON encodings.
 
 # Publishing support
 After a dandiset that contains a zarr archive is published, that zarr archive is immutable.

--- a/doc/design/zarr-support-3.md
+++ b/doc/design/zarr-support-3.md
@@ -1,0 +1,142 @@
+# Zarr Support
+A zarr archive contains directories and zarr files. 
+Zarr archives are stored in their entirety in S3.
+Zarr archives are represented by a single Asset through the API.
+A tree hash is computed as the zarr archive is uploaded.
+Each node in the tree hash in the hash is stored in S3 to avoid bloating the DB.
+Zarr archives as a whole are too big to be copied.
+
+## Publishing support
+We have not yet finalized a plan for publishing zarr archives, so this design is a stopgap measure to support uploading in the meantime.
+Until the plan is finished and implemented, publishing dandisets with zarr archives will simply not be permitted.
+
+# Requirements
+1. Zarr archives are stored in a "directory" in S3.
+1. Each zarr archive corresponds to a single Asset.
+1. The CLI uses some kind of tree hashing scheme to compute a checksum for the entire zarr archive.
+1. The API verifies the checksum _immediately_ after upload.
+1. The system can theoretically handle zarr files with ~1 million subfiles, each of size 64 * 64 * 64 bytes ~= 262 kilobytes.
+1. Zarr metadata must be mutable for zarr files in draft dandisets.
+1. Zarr archives must not be copied, as they are too large to reasonably store multiple copies.
+1. Publishing dandisets with zarr archives is not a requirement at this time.
+
+# Implementation
+
+## API endpoints
+* **POST /api/zarr/**
+
+  Create a new zarr archive.
+
+  Returns a zarr ID
+
+* **GET /api/zarr/{zarr_id}/**
+
+  Returns some information about the zarr archive, like name, S3 path+url, and checksum
+
+* **GET /api/zarr/{zarr_id}/upload/**
+
+  Returns a 204 if an upload is in progress, or a 404 if an upload is not in progress.
+
+* **POST /api/zarr/{zarr_id}/upload/**
+
+  Ask to upload a batch of zarr files as part of the zarr archive.
+  No more batch uploads are permitted until this one is completed or aborted.
+
+  Requires a list of file paths and ETags (md5 checksums).
+  The file paths may include already uploaded files; this is how updates are done.
+
+  Returns a list of presigned upload URLs
+
+* **POST /api/zarr/{zarr_id}/upload/complete/**
+
+  Completes an upload of a batch of zarr files.
+  Fail if any of the checksums do not match.
+  Also, recursively update the tree hash for every parent node for each child.
+
+* **DELETE /api/zarr/{zarr_id}/upload/**
+
+  Cancels a batch upload.
+  Any files already uploaded are deleted.
+  A new batch upload can then be started.
+
+* **DELETE /api/zarr/{zarr_id}/files/**
+
+  Deletes zarr files from S3, and updates the tree hash accordingly.
+  Requires a list of file paths
+
+* **POST /api/dandisets/{...}/versions/{...}/assets/zarr/{zarr_id}/**
+
+  Creates a new Asset that points to the zarr archive.
+  Return an asset ID
+
+When added to a dandiset, zarr archives will appear as a normal `Asset` in all the asset API endpoints.
+There will be a flag `zarr: true` indicating that the asset is a zarr archive.
+
+## Storage implementation
+A zarr archive with a `zarr_id` `c1223302-aff4-44aa-bd4b-952aed997c78` is stored in the public S3 bucket: `dandiarchive/zarr/c1223302-aff4-44aa-bd4b-952aed997c78/...`
+
+Paths for zarr files should never use a `/` prefix.
+`foo/bar.txt` is correct, `/foo/bar.txt` is not.
+
+If a client uploaded a file `1/2/3/foo.bar`, it would be stored at `dandiarchive/zarr/c1223302-aff4-44aa-bd4b-952aed997c78/1/2/3/foo.bar`.
+
+To avoid polluting the zarr archive data, tree hash checksums are stored next to the zarr archive: `dandiarchive/zarr_checksums/c1223302-aff4-44aa-bd4b-952aed997c78/...`
+The algorithm used to generate the checksum files themselves is described below.
+
+## Upload flow
+1. The client `POST`s to create a new zarr archive, or uses existing API endpoints to find the `zarr_id` of a zarr asset to modify.
+1. The client identifies some files in the zarr archive that it wants to upload.
+1. The client calculates the MD5 of each file. 
+1. The client sends the paths+MD5s to `POST .../upload/` and receives a list of presigned upload URLs.
+   * The size of the batch sent can be tuned by the client, up to a certain maximum.
+   * Larger batches mean less overhead, but more data to retry in case of failure.
+1. The client uses the presigned upload URLs to upload the files to S3.
+1. The client notifies the API it is finished with `POST .../upload/complete/`.
+   * The API verifies that all the files are present in S3 and have the correct ETag.
+   * If everything is fine, the upload is marked complete and a new upload can begin.
+1. The client repeats from step 2 until everything is uploaded.
+
+If the zarr archive is ever stuck with a pending upload, that upload can be cancelled by any client.
+
+If any zarr files needs to be deleted from the archive, they can be deleted in bulk using `DELETE .../files/` (up to a certain maximum).
+
+## Tree hashing scheme
+To avoid having to store a checksum in the database for every directory in every zarr file, we will delegate the storage of the checksums to S3.
+
+### Storing tree hash nodes
+For every subdirectory in the zarr archive, a `.checksum` file is also stored in S3 to track the tree hash (algorithm described below).
+
+If a zarr archive `c1223302-aff4-44aa-bd4b-952aed997c78` contained only a single file `1/2/3/foo.bar`, the following `.checksum` files would be generated:
+
+* dandiarchive/zarr_checksums/c1223302-aff4-44aa-bd4b-952aed997c78/1/2/3/.checksum
+* dandiarchive/zarr_checksums/c1223302-aff4-44aa-bd4b-952aed997c78/1/2/.checksum
+* dandiarchive/zarr_checksums/c1223302-aff4-44aa-bd4b-952aed997c78/1/.checksum
+* dandiarchive/zarr_checksums/c1223302-aff4-44aa-bd4b-952aed997c78/.checksum
+
+The last `.checksum` contains the final tree hash for the entire zarr archive.
+
+### .checksum file format
+Each zarr file and directory in the archive has a path and a checksum (`md5`).
+For files, this is simply the ETag.
+For directories, it is calculated like so:
+1. List all immediate children in JSON objects like `{"path": "foo/bar", "md5": "12345...67890"}`.
+1. Order that listing alphabetically by `path`.
+1. Take the resulting JSON list, serialize it to a string, and take the MD5 hash of that string.
+
+For every directory in the zarr archive, the API server maintains a `.checksum` file which contains the checksum of the directory, and also the checksums of the directory contents for easier updates.
+The `.checksum` file is stored in JSON format, exactly like the format used to calculate the checksum:
+```
+{"checksums": [{"path": "foo/bar", "md5": "12345...67890"}, ...], "md5": "09876...54321"}
+```
+
+To update a `.checksum` file, the API server simply needs to read the existing contents, modify `checksums` to reflect the new state of the zarr archive, serialize and calculate the MD5, then save the new contents.
+
+Every update to a `.checksum` file also requires updating the `.checksum` of the parent directory, since the `md5` of the child has change.
+This bubbles up to the top of the zarr archive, where the final `.checksum` for the entire archive can be found.
+
+# Publishing support
+Any dandiset that contains a zarr file cannot be published.
+
+The publish button will be disabled in the GUI with a notice to that effect.
+
+The CLI should also alert the user before they upload a zarr file to a dandiset that this will render the dandiset unpublishable.


### PR DESCRIPTION
Everything required for zarr, except publishing.

I've already started implementing this as it is written with no issues.

Outstanding requests from the last PR:
* calling the `dandiarchive/zarr/...` directory in S3 something else, to reflect that we can store any kind of folder structure in it. I think that we are building this for zarr files, and we are only planning on putting zarr files in it. If there are other formats that we want to explicitly include, we can always create new directories for those formats.
* Keeping `.checksum` files in `dandiarchive/zarr/ZARR_ID.checksum/...` instead of `dandiarchive/zarr_checksums/ZARR_ID/`. I like having two directories for two kinds of files, rather than having `dandiarchive/zarr` contain pairs of directories, but I don't feel that strongly.