### PR TITLE
Paginate asset paths endpoint (take 2)

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -62,9 +62,9 @@ def test_asset_rest_path(
 
     # Do folder assertions
     for folder_path in expected['folders']:
-        assert folder_path in paths['folders']
+        assert folder_path in paths['results']['folders']
 
-        folder_entry = paths['folders'][folder_path]
+        folder_entry = paths['results']['folders'][folder_path]
         folder_assets = list(
             Asset.objects.all().filter(path__startswith=f'{query_prefix}{folder_path}')
         )
@@ -81,10 +81,10 @@ def test_asset_rest_path(
 
     # Do file assertions
     for file_path in expected['files']:
-        assert file_path in paths['files']
+        assert file_path in paths['results']['files']
 
         asset: Asset = Asset.objects.get(path=f'{query_prefix}{file_path}')
-        assert paths['files'][file_path] == AssetSerializer(asset).data
+        assert paths['results']['files'][file_path] == AssetSerializer(asset).data
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from guardian.shortcuts import assign_perm
 import pytest
 import requests
+from rest_framework.test import APIClient
 
 from dandiapi.api.models import Asset, AssetBlob, Version
 from dandiapi.api.views.serializers import AssetFolderSerializer, AssetSerializer
@@ -85,6 +86,62 @@ def test_asset_rest_path(
 
         asset: Asset = Asset.objects.get(path=f'{query_prefix}{file_path}')
         assert paths['results']['files'][file_path] == AssetSerializer(asset).data
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'path,asset_paths,page,expected_count,expected_results',
+    [
+        ('', ['a/b/c/d/e/f/g', 'foo', 'bar/baz'], 1, 3, {'folders': ['a'], 'files': []}),
+        ('', ['a/b/c/d/e/f/g', 'foo', 'bar/baz'], 2, 3, {'folders': ['bar'], 'files': []}),
+        ('', ['a/b/c/d/e/f/g', 'foo', 'bar/baz'], 3, 3, {'folders': [], 'files': ['foo']}),
+    ],
+)
+def test_asset_rest_path_pagination(
+    api_client: APIClient,
+    draft_version_factory,
+    asset_factory,
+    asset_blob_factory,
+    path: str,
+    asset_paths: list,
+    page: int,
+    expected_count: int,
+    expected_results: dict,
+):
+    # Initialize version and contained assets
+    asset_blob = asset_blob_factory()
+    assets = [asset_factory(blob=asset_blob, path=p) for p in asset_paths]
+    version: Version = draft_version_factory()
+    for asset in assets:
+        version.assets.add(asset)
+
+    # Retrieve paths from endpoint
+    paths = api_client.get(
+        f'/api/dandisets/{version.dandiset.identifier}/'
+        f'versions/{version.version}/assets/paths/',
+        {'path_prefix': path, 'page': page, 'page_size': 1},
+    ).data
+
+    assert paths.get('count') == expected_count
+
+    assert (
+        paths.get('previous') is None
+        if page == 1
+        else f'/api/dandisets/{version.dandiset.identifier}/versions'
+        f'/draft/assets/paths/?page={page-1}&page_size=1'
+    )
+
+    assert (
+        paths.get('next') is None
+        if page == expected_count
+        else f'/api/dandisets/{version.dandiset.identifier}/versions'
+        f'/draft/assets/paths/?page={page+1}&page_size=1'
+    )
+
+    for item_type in ('files', 'folders'):
+        assert len(paths['results'][item_type]) == len(expected_results[item_type])
+        for name in paths['results']['folders']:
+            assert name in expected_results['folders']
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -374,7 +374,7 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         if page_size > DandiPagination.max_page_size:
             page_size = DandiPagination.max_page_size
 
-        qs = self.get_queryset().select_related('blob').filter(path__startswith=path_prefix)
+        qs = self.get_queryset().select_related('blob').filter(path__startswith=path_prefix).order_by('path')
 
         assets: dict[str, Union[Asset, dict]] = {}
 

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -88,15 +88,18 @@ def _paginate_asset_paths(
     assets_page: Page = paths_paginator.page(page)
 
     # Divide into folders and files
-    paths = {'folders': {}, 'files': {}}
-    folder_files = [paths['folders'], paths['files']]
+    folders = {}
+    files = {}
 
     # Note that this loop runs in constant time, since the length of assets_page
     # will never exceed DandiPagination.max_page_size.
     for k, v in dict(assets_page).items():
-        folder_files[int(isinstance(v, Asset))][k] = v
+        if isinstance(v, Asset):
+            files[k] = v
+        else:
+            folders[k] = v
 
-    paths = AssetPathsSerializer(paths)
+    paths = AssetPathsSerializer({'folders': folders, 'files': 'files'})
 
     # generate other parameters for the paginated response
     url_kwargs = {

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -371,6 +371,9 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
         page_size: int = int(
             self.request.query_params.get('page_size') or DandiPagination.page_size
         )
+        if page_size > DandiPagination.max_page_size:
+            page_size = DandiPagination.max_page_size
+
         qs = self.get_queryset().select_related('blob').filter(path__startswith=path_prefix)
 
         assets: dict[str, Union[Asset, dict]] = {}


### PR DESCRIPTION
Manually paginates the asset paths endpoint. Also improves performance by removing the calls to the `AssetSerializer` constructor on every iteration of the asset loop.