### PR TITLE
Update deprecated `before_binding` to `mutate_configuration`

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -25,7 +25,7 @@ class DandiMixin(ConfigMixin):
     DANDI_ALLOW_LOCALHOST_URLS = False
 
     @staticmethod
-    def before_binding(configuration: Type[ComposedConfiguration]):
+    def mutate_configuration(configuration: Type[ComposedConfiguration]):
         # Install local apps first, to ensure any overridden resources are found first
         configuration.INSTALLED_APPS = [
             'dandiapi.api.apps.PublishConfig',


### PR DESCRIPTION
django-composed-configuration has deprecated `before_binding` in favor of `mutate_configuration`.