### PR TITLE
Revert "Update deprecated `before_binding` to `mutate_configuration`"

### DIFF
--- a/dandiapi/settings.py
+++ b/dandiapi/settings.py
@@ -25,7 +25,7 @@ class DandiMixin(ConfigMixin):
     DANDI_ALLOW_LOCALHOST_URLS = False
 
     @staticmethod
-    def mutate_configuration(configuration: Type[ComposedConfiguration]):
+    def before_binding(configuration: Type[ComposedConfiguration]):
         # Install local apps first, to ensure any overridden resources are found first
         configuration.INSTALLED_APPS = [
             'dandiapi.api.apps.PublishConfig',


### PR DESCRIPTION
Reverts dandi/dandi-api#585

Staging deploys are failing ever since this change was introduced. We should still ultimately make the change to `mutate_configuration` since `before_binding` is deprecated, but merging this will tell us if that is the cause of the deploy failures or something else entirely. 