### PR TITLE
Collect first and last names from users who don't have them

### DIFF
--- a/dandiapi/api/templates/api/account/questionnaire_form.html
+++ b/dandiapi/api/templates/api/account/questionnaire_form.html
@@ -23,6 +23,9 @@
       </div>
     </div>
   </form>
+  <div style="margin-top: 4%">
+    Contact us at <a href="mailto:help@dandiarchive.org">help@dandiarchive.org</a> if you have any questions.
+  </div>
 
   <script>
     // Length validation


### PR DESCRIPTION
This is one potential solution to #570.

This adds a check to the `oauth/authorize` endpoint that is called whenever a user logs in. If the user doesn't have a first or last name, they are redirected to a form that they must fill out before being allowed to log in. This would need to be accompanied by a manual operation to revoke all session cookies from users without first or last names.

Closes #570