### PR TITLE
Management script to restore missing schema keys

### DIFF
--- a/dandiapi/api/management/commands/repair_schema_keys.py
+++ b/dandiapi/api/management/commands/repair_schema_keys.py
@@ -1,0 +1,31 @@
+import djclick as click
+
+from dandiapi.api.models import Version
+
+# maps name of metadata field to its correct value for "schemaKey"
+SCHEMA_KEYS = {
+    '': 'Dandiset',
+    'access': 'AccessRequirements',
+    'relatedResource': 'Resource',
+    'assetsSummary': 'AssetsSummary',
+}
+
+
+@click.command()
+def repair_schema_keys():
+    versions = Version.objects.filter(validation_errors__isnull=False)
+    for version in versions:
+        for error in version.validation_errors:
+            if "'schemaKey' is a required property" in error['message']:
+                error_split: list[str] = error['field'].split('.')
+                field = error_split[0]
+
+                if field == '':
+                    version.metadata['schemaKey'] = SCHEMA_KEYS[field]
+                elif len(error_split) == 1:
+                    version.metadata[field]['schemaKey'] = SCHEMA_KEYS[field]
+                else:
+                    # handles cases where error is like "relatedResource.0"
+                    index = int(error_split[1])
+                    version.metadata[field][index]['schemaKey'] = SCHEMA_KEYS[field]
+                version.save()


### PR DESCRIPTION
Following up on https://github.com/dandi/dandiarchive/issues/954#issuecomment-965295820

<details>
<summary>The following dandisets were affected in production:</summary>
<br>

```
{'field': '', 'message': "'schemaKey' is a required property"}
000146

{'field': 'access.0', 'message': "'schemaKey' is a required property"}
000161

{'field': '', 'message': "'schemaKey' is a required property"}
000144

{'field': '', 'message': "'schemaKey' is a required property"}
000145

{'field': 'access.0', 'message': "'schemaKey' is a required property"}
000119

{'field': 'relatedResource.0', 'message': "'schemaKey' is a required property"}
000165

{'field': 'relatedResource.1', 'message': "'schemaKey' is a required property"}
000165

{'field': 'access.0', 'message': "'schemaKey' is a required property"}
000156

{'field': 'assetsSummary', 'message': "'schemaKey' is a required property"}
000025
```
</details>

This PR adds a one-off management script that will restore the schema key field to those dandisets. 