### PR TITLE
Update subject line on review email

### DIFF
--- a/dandiapi/api/mail.py
+++ b/dandiapi/api/mail.py
@@ -77,7 +77,7 @@ def build_new_user_messsage(user: User, socialaccount: SocialAccount = None):
     }
     # Email sent to the DANDI list when a new user logs in for the first time
     return build_message(
-        subject=f'DANDI: New user registration to review: {user.username}',
+        subject=f'DANDI: Review new user: {user.username}',
         message=render_to_string('api/mail/new_user_message.txt', render_context),
         to=['dandi@mit.edu'],
         html_message=render_to_string('api/mail/new_user_message.html', render_context),

--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -36,7 +36,7 @@ def test_user_registration_email(social_account, mailoutbox, api_client):
     assert all(len(_) < 100 for _ in email.body.splitlines())
 
     email = mailoutbox[1]
-    assert email.subject == f'DANDI: New user registration to review: {user.username}'
+    assert email.subject == f'DANDI: Review new user: {user.username}'
     assert email.to == ['dandi@mit.edu']
     assert '<p>' not in email.body
     assert all(len(_) < 100 for _ in email.body.splitlines())


### PR DESCRIPTION
This visually separates the "need to register" emails from the "there's a new user" emails.