### PR TITLE
Use odysseus in tests with names

### DIFF
--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -33,11 +33,11 @@ class SocialAccountFactory(factory.django.DjangoModelFactory):
 
     @factory.lazy_attribute
     def extra_data(self):
-        first_name = faker.Faker().first_name()
-        last_name = faker.Faker().last_name()
+        first_name = self.user.first_name
+        last_name = self.user.last_name
         name = f'{first_name} {last_name}'
         return {
-            'login': first_name,
+            'login': self.user.username,
             'name': name,
             'email': self.user.username,
         }

--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -122,9 +122,9 @@ def test_user_search_multiple_matches(api_client, user, user_factory, social_acc
     api_client.force_authenticate(user=user)
 
     usernames = [
-        'jane_bar',
-        'jane_doe',
-        'jane_foo',
+        'odysseus_bar',
+        'odysseus_doe',
+        'odysseus_foo',
         # Some extra users to be filtered out
         'john_bar',
         'john_doe',
@@ -136,7 +136,7 @@ def test_user_search_multiple_matches(api_client, user, user_factory, social_acc
     assert (
         api_client.get(
             '/api/users/search/?',
-            {'username': 'jane'},
+            {'username': 'odysseus'},
             format='json',
         ).data
         == [serialize_social_account(social_account) for social_account in social_accounts[:3]]
@@ -147,14 +147,14 @@ def test_user_search_multiple_matches(api_client, user, user_factory, social_acc
 def test_user_search_limit_enforced(api_client, user, user_factory, social_account_factory):
     api_client.force_authenticate(user=user)
 
-    usernames = [f'jane_{i:02}' for i in range(0, 20)]
+    usernames = [f'odysseus_{i:02}' for i in range(0, 20)]
     users = [user_factory(username=username) for username in usernames]
     social_accounts = [social_account_factory(user=user) for user in users]
 
     assert (
         api_client.get(
             '/api/users/search/?',
-            {'username': 'jane'},
+            {'username': 'odysseus'},
             format='json',
         ).data
         == [serialize_social_account(social_account) for social_account in social_accounts[:10]]

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -88,7 +88,7 @@ def users_search_view(request: Request) -> HttpResponseBase:
         extra_data__icontains=username,
         user__is_active=True,
         user__metadata__status=UserMetadata.Status.APPROVED,
-    )[:10]
+    ).order_by('date_joined')[:10]
     users = [social_account_to_dict(social_account) for social_account in social_accounts]
 
     # Try searching Django's regular `User`s if there aren't any results.


### PR DESCRIPTION
Previously we used `jane` as a generic name for user search tests. This
worked most of the time, but would break whenever the User factory
happened to generate a use with the name `Jane`.
Switch the generic name to `Odysseus`, which is presumably not in
Fakers name pool.

Take 2: explicitly order the users in the search endpoint.
Also clean up the SocialAccountFactory a bit to tie it more tightly to the base User object.