### PR TITLE
Cleanup testing

### DIFF
--- a/dandiapi/api/tests/conftest.py
+++ b/dandiapi/api/tests/conftest.py
@@ -42,6 +42,12 @@ register(SocialAccountFactory)
 register(UploadFactory)
 
 
+@pytest.fixture
+def user(user_factory):
+    """Override the default `user` fixture to use our `UserFactory` so `UserMetadata` works."""
+    return user_factory()
+
+
 @pytest.fixture(params=[DraftAssetFactory, PublishedAssetFactory], ids=['draft', 'published'])
 def asset_factory(request):
     return request.param

--- a/dandiapi/api/tests/factories.py
+++ b/dandiapi/api/tests/factories.py
@@ -10,6 +10,13 @@ import faker
 from dandiapi.api.models import Asset, AssetBlob, Dandiset, Upload, UserMetadata, Version
 
 
+class UserMetadataFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = UserMetadata
+
+    status = UserMetadata.Status.APPROVED
+
+
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
@@ -19,9 +26,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     first_name = factory.Faker('first_name')
     last_name = factory.Faker('last_name')
 
-    @factory.post_generation
-    def post(self, create, extracted, **kwargs):
-        UserMetadata.objects.create(user=self, status=UserMetadata.Status.APPROVED)
+    metadata = factory.RelatedFactory(UserMetadataFactory, factory_related_name='user')
 
 
 class SocialAccountFactory(factory.django.DjangoModelFactory):

--- a/tox.ini
+++ b/tox.ini
@@ -91,8 +91,6 @@ DJANGO_SETTINGS_MODULE = dandiapi.settings
 DJANGO_CONFIGURATION = TestingConfiguration
 addopts = --strict-markers --showlocals --verbose
 filterwarnings =
+    ignore:.*default_app_config*.:django.utils.deprecation.RemovedInDjango41Warning
     ignore::DeprecationWarning:minio
     ignore::DeprecationWarning:configurations
-    ignore::django.utils.deprecation.RemovedInDjango40Warning:oauth2_provider
-    # The DEFAULT_HASHING_ALGORITHM warning is caused by Django Configurations
-    ignore:.*DEFAULT_HASHING_ALGORITHM.*:django.utils.deprecation.RemovedInDjango40Warning:django


### PR DESCRIPTION
I learned recently that the `factory.post_generation` decorator is usually used to represent many-to-many relationships with Factory Boy, and that `RelatedFactory`/`RelatedFactoryList` is a thing and lets you express one-to-one/one-to-many relationships more naturally. This PR changes the way `UserFactory` handles `UserMetadata` to take advantage of `RelatedFactory` instead.

I've also updated the pytest config settings in `tox.ini` to the ones in the latest cookiecutter. This will eliminate those Django 4 warnings that keep appearing after every test run, which I found made the tests more annoying to read when I was debugging a test failure recently.