### PR TITLE
Return names for users with no social account

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -595,7 +595,7 @@ def test_dandiset_rest_get_owners_no_social_account(api_client, dandiset, user):
     resp = api_client.get(f'/api/dandisets/{dandiset.identifier}/users/')
 
     assert resp.status_code == 200
-    assert resp.data == [{'username': user.username}]
+    assert resp.data == [{'username': user.username, 'name': f'{user.first_name} {user.last_name}'}]
 
 
 @pytest.mark.django_db

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -298,5 +298,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                 owners.append(owner_dict)
             except SocialAccount.DoesNotExist:
                 # Just in case some users aren't using social accounts, have a fallback
-                owners.append({'username': owner.username})
+                owners.append(
+                    {'username': owner.username, 'name': f'{owner.first_name} {owner.last_name}'}
+                )
         return Response(owners, status=status.HTTP_200_OK)


### PR DESCRIPTION
This lets the frontend properly display owners' names when an owner does not have an associated `SocialAccount` (which is always true in local dev and E2E browser testing environments).