### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,6 @@ Then go to `/swagger` and use `GET /auth/token` end-point.
 In API endpoint calls, add the `Authorization` HTTP header with a value of
 `Token <token_value>`. For example, for a token `1234`, include the header:
 `Authorization: Token 1234`.
+
+## Custom management scripts
+Documentation for the various custom `manage.py` scripts can be found in `DEVELOPMENT.md`.

--- a/README.md
+++ b/README.md
@@ -55,10 +55,7 @@ but allows developers to run Python code on their native system.
 3. Run in a separate terminal:
    1. `source ./dev/export-env.sh`
    2. `celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat -Q celery,calculate_sha256 -B`
-4. Run in a seperate terminal:
-   1. `source ./dev/export-env.sh`
-   2. `celery --app dandiapi.celery beat --loglevel INFO`
-5. When finished, run `docker-compose stop`
+4. When finished, run `docker-compose stop`
 
 ## Remap Service Ports (optional)
 Attached services may be exposed to the host system via alternative ports. Developers who work

--- a/README.md
+++ b/README.md
@@ -48,14 +48,17 @@ but allows developers to run Python code on their native system.
    to create a dummy dandiset to start working with.
 
 ### Run Application
-1.  Ensure `docker-compose -f ./docker-compose.yml up -d` is still active
+1. Ensure `docker-compose -f ./docker-compose.yml up -d` is still active
 2. Run:
    1. `source ./dev/export-env.sh`
    2. `./manage.py runserver`
 3. Run in a separate terminal:
    1. `source ./dev/export-env.sh`
-   2. `celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat`
-4. When finished, run `docker-compose stop`
+   2. `celery --app dandiapi.celery worker --loglevel INFO --without-heartbeat -Q celery,calculate_sha256 -B`
+4. Run in a seperate terminal:
+   1. `source ./dev/export-env.sh`
+   2. `celery --app dandiapi.celery beat --loglevel INFO`
+5. When finished, run `docker-compose stop`
 
 ## Remap Service Ports (optional)
 Attached services may be exposed to the host system via alternative ports. Developers who work

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,7 +17,7 @@ services:
       - rabbitmq
       - minio
 
-  celery_worker:
+  celery:
     build:
       context: .
       dockerfile: ./dev/django.Dockerfile
@@ -31,25 +31,6 @@ services:
       "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
-    tty: false
-    env_file: ./dev/.env.docker-compose
-    volumes:
-      - .:/opt/django-project
-    depends_on:
-      - postgres
-      - rabbitmq
-      - minio
-
-  celery_beat:
-    build:
-      context: .
-      dockerfile: ./dev/django.Dockerfile
-    command: [
-      "celery",
-      "--app", "dandiapi.celery",
-      "beat",
-      "--loglevel", "INFO"
-    ]
     tty: false
     env_file: ./dev/.env.docker-compose
     volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,7 +17,7 @@ services:
       - rabbitmq
       - minio
 
-  celery:
+  celery_worker:
     build:
       context: .
       dockerfile: ./dev/django.Dockerfile
@@ -31,6 +31,25 @@ services:
       "-B"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors
+    tty: false
+    env_file: ./dev/.env.docker-compose
+    volumes:
+      - .:/opt/django-project
+    depends_on:
+      - postgres
+      - rabbitmq
+      - minio
+
+  celery_beat:
+    build:
+      context: .
+      dockerfile: ./dev/django.Dockerfile
+    command: [
+      "celery",
+      "--app", "dandiapi.celery",
+      "beat",
+      "--loglevel", "INFO"
+    ]
     tty: false
     env_file: ./dev/.env.docker-compose
     volumes:


### PR DESCRIPTION
Adds
	- Note about where to find `manage.py` scripts documentation to README
	- Instructions for running celery beat to README (which is now required for things to work correctly locally)
	- celery beat as a service in `docker-compose.override.yml`