### PR TITLE
User admin dashboard page

### DIFF
--- a/dandiapi/api/dashboard.py
+++ b/dandiapi/api/dashboard.py
@@ -5,7 +5,9 @@ from django.db.models import Exists, OuterRef, Q
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_http_methods
 from django.views.generic.base import TemplateView
+from django_filters.views import FilterView
 
+from dandiapi.api.filters import UserStatusFilter
 from dandiapi.api.mail import send_approved_user_message, send_rejected_user_message
 from dandiapi.api.models import Asset, AssetBlob, Upload, UserMetadata, Version
 from dandiapi.api.views.users import social_account_to_dict
@@ -68,6 +70,11 @@ class DashboardView(TemplateView):
             .filter(metadata__status=UserMetadata.Status.APPROVED)
             .order_by('-date_joined')
         )
+
+
+class UserDashboardView(FilterView):
+    template_name = 'dashboard/users.html'
+    filterset_class = UserStatusFilter
 
 
 @require_http_methods(['GET', 'POST'])

--- a/dandiapi/api/filters.py
+++ b/dandiapi/api/filters.py
@@ -1,0 +1,8 @@
+from django.contrib.auth.models import User
+import django_filters
+
+
+class UserStatusFilter(django_filters.FilterSet):
+    class Meta:
+        model = User
+        fields = ['metadata__status']

--- a/dandiapi/api/templates/dashboard/base.html
+++ b/dandiapi/api/templates/dashboard/base.html
@@ -5,3 +5,17 @@
 {% block branding %}
 <h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
 {% endblock %}
+
+{% block breadcrumbs %}
+<style>
+  .dandi-navbar-link {
+    margin-right: 2em;
+  }
+</style>
+<div class="breadcrumbs">
+  <a class="dandi-navbar-link" href="{% url 'dashboard-index' %}">Dashboard Home</a>
+  <a class="dandi-navbar-link" href="{% url 'dashboard-users' %}">Users Dashboard</a>
+  <a class="dandi-navbar-link" href="{% url 'admin:index' %}">Admin</a>
+  {% if title %} &rsaquo; {{ title }}{% endif %}
+</div>
+{% endblock %}

--- a/dandiapi/api/templates/dashboard/base.html
+++ b/dandiapi/api/templates/dashboard/base.html
@@ -1,0 +1,7 @@
+{% extends "admin/base.html" %}
+
+{% block title %} Data Dashboard {% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}

--- a/dandiapi/api/templates/dashboard/index.html
+++ b/dandiapi/api/templates/dashboard/index.html
@@ -1,12 +1,4 @@
-{% extends "admin/base.html" %}
-
-{% block title %} Data Dashboard {% endblock %}
-
-{% block branding %}
-<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
-{% endblock %}
-
-{% block nav-global %}{% endblock %}
+{% extends "dashboard/base.html" %}
 
 {% block content %}
 <div id="content-main">

--- a/dandiapi/api/templates/dashboard/index.html
+++ b/dandiapi/api/templates/dashboard/index.html
@@ -102,42 +102,5 @@
     </table>
     {% endif %}
   </div>
-
-  <div>
-    <h1>Approved Users</h1>
-    <p>There are currently {{ user_count }} approved users.</p>
-    <!-- Two different tables so that emails can be copied easily -->
-    <table style="float: left">
-      <thead>
-        <tr>
-          <td>Email</td>
-        </tr>
-      </thead>
-      {% for user in users %}
-      <tr>
-        <td> {{ user.email }} </td>
-      </tr>
-      {% endfor %}
-    </table>
-    <table style="float: left">
-      <thead>
-        <tr>
-          <td>First name</td>
-          <td>Last name</td>
-          <td>Date joined</td>
-          <td>Status</td>
-        </tr>
-      </thead>
-      {% for user in users %}
-      <tr>
-        <td>{{ user.first_name }}</td>
-        <td>{{ user.last_name }}</td>
-        <td>{{ user.date_joined }}</td>
-        <td><a href="{% url 'user-approval' user.username %}">{{ user.metadata.status }}</a></td>
-      </tr>
-      {% endfor %}
-    </table>
-  </div>
-
 </div>
 {% endblock %}

--- a/dandiapi/api/templates/dashboard/user_approval.html
+++ b/dandiapi/api/templates/dashboard/user_approval.html
@@ -1,12 +1,6 @@
-{% extends "admin/base.html" %}
+{% extends "dashboard/base.html" %}
 
 {% block title %} User Approval {% endblock %}
-
-{% block branding %}
-<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
-{% endblock %}
-
-{% block nav-global %}{% endblock %}
 
 {% block extrastyle %}
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/dandiapi/api/templates/dashboard/users.html
+++ b/dandiapi/api/templates/dashboard/users.html
@@ -1,0 +1,51 @@
+{% extends "dashboard/base.html" %}
+
+{% block title %} Data Dashboard: Users {% endblock %}
+
+{% block content %}
+<div>
+  <h1>Users</h1>
+
+  <div style="margin-bottom: 2%;">
+    <form action="" method="get">
+      {{ filter.form.as_p }}
+      <input type="submit" value="Apply filter" />
+    </form>
+    {% for value in filter.data.values %}
+      <p>There are currently {{ filter.qs.count }} {{ value }} users.</p>
+    {% endfor %}
+  </div>
+
+  <!-- Two different tables so that emails can be copied easily -->
+  <table style="float: left">
+    <thead>
+      <tr>
+        <td>Email</td>
+      </tr>
+    </thead>
+    {% for user in filter.qs %}
+    <tr>
+      <td> {{ user.email }} d</td>
+    </tr>
+    {% endfor %}
+  </table>
+  <table style="float: left">
+    <thead>
+      <tr>
+        <td>First name</td>
+        <td>Last name</td>
+        <td>Date joined</td>
+        <td>Status</td>
+      </tr>
+    </thead>
+    {% for user in filter.qs %}
+    <tr>
+      <td>{{ user.first_name }}</td>
+      <td>{{ user.last_name }}</td>
+      <td>{{ user.date_joined }}</td>
+      <td><a href="{% url 'user-approval' user.username %}">{{ user.metadata.status }}</a></td>
+    </tr>
+    {% endfor %}
+  </table>
+</div>
+{% endblock content %}

--- a/dandiapi/api/tests/test_dashboard.py
+++ b/dandiapi/api/tests/test_dashboard.py
@@ -1,0 +1,39 @@
+from random import randint
+
+from django.contrib.auth.models import User
+from django.test.client import Client
+from django.urls import reverse
+import pytest
+from pytest_django.asserts import assertContains
+
+from dandiapi.api.models import UserMetadata
+
+
+@pytest.mark.django_db
+def test_users_dashboard(client: Client, admin_client: Client, user, user_factory):
+    for status, _ in UserMetadata.Status.choices:
+        for _ in range(randint(0, 10)):
+            user = user_factory()
+            user.metadata.status = status
+            user.metadata.save()
+
+    for status, _ in UserMetadata.Status.choices:
+        page_url = f'{reverse("dashboard-users")}?metadata__status={status}'
+
+        # Non-admin users should be redirected to a login page
+        assert client.get(page_url).status_code == 302
+
+        resp = admin_client.get(page_url)
+
+        assert resp.status_code == 200
+
+        assertContains(
+            resp,
+            f'There are currently {User.objects.filter(metadata__status=status).count()}'
+            f' {status} users',
+        )
+
+        for user in User.objects.filter(metadata__status=status):
+            assertContains(resp, user.email)
+            assertContains(resp, user.first_name)
+            assertContains(resp, user.last_name)

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -6,7 +6,7 @@ from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 
-from dandiapi.api.dashboard import DashboardView, user_approval_view
+from dandiapi.api.dashboard import DashboardView, UserDashboardView, user_approval_view
 from dandiapi.api.views import (
     AssetViewSet,
     DandisetViewSet,
@@ -105,6 +105,7 @@ urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
     path('dashboard/', DashboardView.as_view()),
+    path('dashboard/users/', UserDashboardView.as_view()),
     path('dashboard/user/<str:username>/', user_approval_view, name='user-approval'),
     # this url overrides the authorize url in oauth2_provider.urls to
     # support our user signup workflow

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -104,8 +104,8 @@ urlpatterns = [
     ),
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
-    path('dashboard/', DashboardView.as_view()),
-    path('dashboard/users/', UserDashboardView.as_view()),
+    path('dashboard/', DashboardView.as_view(), name='dashboard-index'),
+    path('dashboard/users/', UserDashboardView.as_view(), name='dashboard-users'),
     path('dashboard/user/<str:username>/', user_approval_view, name='user-approval'),
     # this url overrides the authorize url in oauth2_provider.urls to
     # support our user signup workflow


### PR DESCRIPTION
We already have a list of *approved* users in the dashboard, so to address #575 I moved that list to a separate dashboard page and added a filter for user `status`. I also added a new `DashboardMixin` that can be subclassed by all dashboard pages to ensure only admins are allowed to view them. I think this is a cleaner approach to authentication over raising an exception in `get_context_data` now that we have multiple dashboard views.

Closes #575.