### PR TITLE
Fix flaky test

### DIFF
--- a/dandiapi/api/models/dandiset.py
+++ b/dandiapi/api/models/dandiset.py
@@ -29,7 +29,7 @@ class Dandiset(TimeStampedModel):
 
     @property
     def owners(self):
-        return get_users_with_perms(self, only_with_perms_in=['owner'])
+        return get_users_with_perms(self, only_with_perms_in=['owner']).order_by('date_joined')
 
     def set_owners(self, new_owners):
         old_owners = get_users_with_perms(self, only_with_perms_in=['owner'])


### PR DESCRIPTION
I noticed some test flake on https://github.com/dandi/dandi-api/actions/runs/1559780662/attempts/1

(That run was from my PR that pinned the Django version, which did not touch any endpoints. Note the second attempt of that run succeeds.)

I ran the test in question locally (`test_dandiset_rest_add_owner`) 1000 times and got 335 failures, all of which failed because the ordering was off. 

In other words the test expected 

`[{'username': 'user1'}, {'username': 'user2'}]` 

but roughly a third of the time the API server would return 

`[{'username': 'user2'}, {'username': 'user1'}]`

This suggests the order of the list returned by the Django guardian `get_users_with_perms` function is not deterministic. This PR explicilty orders the list before returning it. I ran the problematic test with these changes 10000 times and nothing failed.
