### PR TITLE
Fix user approval page styling when browser is in dark mode

### DIFF
--- a/dandiapi/api/templates/dashboard/user_approval.html
+++ b/dandiapi/api/templates/dashboard/user_approval.html
@@ -14,6 +14,18 @@
 {% endblock %}
 
 {% block content %}
+<style>
+/*
+  Materialize CSS's 'collection' component doesn't work properly with the
+  dark mode setting present in some browsers. To fix this, manually
+  override the bg color when the user has their browser set to dark mode.
+*/
+@media (prefers-color-scheme: dark) {
+  .collection-item {
+    background-color: var(--body-bg) !important;
+  }
+}
+</style>
 <div id="content-main">
   <div>
     <ul class="collection">


### PR DESCRIPTION
I believe @satra mentioned this before.

The user approval admin page is difficult to read when using the "dark mode" browser setting. This is because the CSS framework we're using for this view doesn't support this mode (yet?). To fix this, I added a CSS media query to darken the background color when the user is in dark mode. The page remains the same for users not using dark mode.

Current page in dark mode:
![before](https://user-images.githubusercontent.com/37340715/145479844-b5c65d4a-8575-463d-ad77-2a548bdeb8ae.png)

New page in dark mode:

![after](https://user-images.githubusercontent.com/37340715/145479915-7f10162a-7895-4ebd-aaa1-4474b5a0c7ab.png)

