### PR TITLE
Order .checksum JSON object keys alphabetically

### DIFF
--- a/dandiapi/api/tests/test_zarr_checksums.py
+++ b/dandiapi/api/tests/test_zarr_checksums.py
@@ -30,23 +30,23 @@ def test_zarr_checksum_sort_order():
 @pytest.mark.parametrize(
     'file_checksums,directory_checksums,checksum',
     [
-        ([], [], 'deb10f9b7b3275dc058b71f011525789'),
-        ([ZarrChecksum(path='foo/bar', md5='a')], [], '5a815bced8a21b433e1074feebbde86e'),
-        ([], [ZarrChecksum(path='foo/bar', md5='a')], '5f4c8223552adf78f375063e42874328'),
+        ([], [], '481a2f77ab786a0f45aafd5db0971caa'),
+        ([ZarrChecksum(path='foo/bar', md5='a')], [], 'cdcfdfca3622e20df03219273872549e'),
+        ([], [ZarrChecksum(path='foo/bar', md5='a')], '243aca82c6872222747183dd738b6fcb'),
         (
             [ZarrChecksum(path='foo/bar', md5='a'), ZarrChecksum(path='foo/baz', md5='b')],
             [],
-            'b2a825702d706090faf13fd18cc2db99',
+            '785295076ae9156b363e442ef6d485e0',
         ),
         (
             [],
             [ZarrChecksum(path='foo/bar', md5='a'), ZarrChecksum(path='foo/baz', md5='b')],
-            '176ebfa3adc85bd2c428297fc39c2334',
+            'ebca8bb8e716237e0f71657d1045930f',
         ),
         (
             [ZarrChecksum(path='foo/baz', md5='a')],
             [ZarrChecksum(path='foo/bar', md5='b')],
-            '437319759d2ab0e6f62ef5ca7a9b822a',
+            '9c34644ba03b7e9f58ebd1caef4215ad',
         ),
     ],
 )
@@ -67,7 +67,7 @@ def test_zarr_checksum_serializer_generate_listing():
         directories=[ZarrChecksum(path='foo/baz', md5='b')],
     )
     assert serializer.generate_listing(checksums) == ZarrChecksumListing(
-        checksums=checksums, md5='a1dc945351c72ecacd237063d68f5eb4'
+        checksums=checksums, md5='23076057c0da63f8ab50d0a108db332c'
     )
 
 
@@ -83,14 +83,14 @@ def test_zarr_serialize():
                 md5='c',
             )
         )
-        == '{"checksums":{"files":[{"path":"foo/bar","md5":"a"}],"directories":[{"path":"bar/foo","md5":"b"}]},"md5":"c"}'  # noqa: E501
+        == '{"checksums":{"directories":[{"md5":"b","path":"bar/foo"}],"files":[{"md5":"a","path":"foo/bar"}]},"md5":"c"}'  # noqa: E501
     )
 
 
 def test_zarr_deserialize():
     serializer = ZarrJSONChecksumSerializer()
     assert serializer.deserialize(
-        '{"checksums":{"files":[{"path":"foo/bar","md5":"a"}],"directories":[{"path":"bar/foo","md5":"b"}]},"md5":"c"}'  # noqa: E501
+        '{"checksums":{"directories":[{"md5":"b","path":"bar/foo"}],"files":[{"md5":"a","path":"foo/bar"}]},"md5":"c"}'  # noqa: E501
     ) == ZarrChecksumListing(
         checksums=ZarrChecksums(
             files=[ZarrChecksum(path='foo/bar', md5='a')],

--- a/dandiapi/api/zarr_checksums.py
+++ b/dandiapi/api/zarr_checksums.py
@@ -25,8 +25,8 @@ class ZarrChecksum(pydantic.BaseModel):
     Every file and directory in a zarr archive has a path and a MD5 hash.
     """
 
-    path: str
     md5: str
+    path: str
 
     # To make ZarrChecksums sortable
     def __lt__(self, other: ZarrChecksum):
@@ -40,8 +40,8 @@ class ZarrChecksums(pydantic.BaseModel):
     This is the data hashed to calculate the checksum of a directory.
     """
 
-    files: List[ZarrChecksum] = pydantic.Field(default_factory=list)
     directories: List[ZarrChecksum] = pydantic.Field(default_factory=list)
+    files: List[ZarrChecksum] = pydantic.Field(default_factory=list)
 
     @property
     def is_empty(self):

--- a/doc/design/zarr-support-3.md
+++ b/doc/design/zarr-support-3.md
@@ -126,14 +126,14 @@ The last `.checksum` contains the final tree hash for the entire zarr archive.
 Each zarr file and directory in the archive has a path and a checksum (`md5`).
 For files, this is simply the ETag.
 For directories, it is calculated like so:
-1. List all immediate child files and directories in JSON objects like `{"path":"foo/bar","md5":"12345...67890"}`.
-1. Create an object `{"files":[...],"directories":[...]}` containing those child objects, ordered alphabetically by `path`.
+1. List all immediate child files and directories in JSON objects like `{"md5":"12345...67890","path":"foo/bar"}` (key order matters).
+1. Create an object `{"directories":[...],"files":[...]}` (key order matters) containing those child objects, ordered alphabetically by `path`.
 1. Take the resulting JSON list, serialize it to a string, and take the MD5 hash of that string.
 
 For every directory in the zarr archive, the API server maintains a `.checksum` file which contains the checksum of the directory, and also the checksums of the directory contents for easier updates.
 The `.checksum` file is stored in JSON format, exactly like the format used to calculate the checksum:
 ```
-{"checksums":{"files":[{"path":"foo/bar","md5":"12345...67890"},...],"directories":[{"path":"foo/baz","md5":"abc...def"},...]},"md5":"09876...54321"}
+{"checksums":{"directories":[{"md5":"abc...def","path":"foo/baz"},...],"files":[{"md5":"12345...67890","path":"foo/bar"},...]},"md5":"09876...54321"}
 ```
 
 To update a `.checksum` file, the API server simply needs to read the existing contents, modify `checksums` to reflect the new state of the zarr archive, serialize and calculate the MD5, then save the new contents.


### PR DESCRIPTION
* Swap the order of checksum object keys: `{"md5":"...","path":"..."}`
* Swap the order of checksum listing object keys: `{"directories":...,"files":...}`
Everything should now be alphabetical.
Fixes #631 