### PR TITLE
Embargo create dandiset

### DIFF
--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -614,7 +614,7 @@ def test_dandiset_rest_create_embargoed(api_client, user):
     metadata = {'foo': 'bar'}
 
     response = api_client.post(
-        '/api/dandisets/?embargo', {'name': name, 'metadata': metadata}, format='json'
+        '/api/dandisets/?embargo=true', {'name': name, 'metadata': metadata}, format='json'
     )
     assert response.data == {
         'identifier': DANDISET_ID_RE,

--- a/dandiapi/api/tests/test_dandiset.py
+++ b/dandiapi/api/tests/test_dandiset.py
@@ -605,6 +605,96 @@ def test_dandiset_rest_create_with_contributor(api_client, admin_user):
 
 
 @pytest.mark.django_db
+def test_dandiset_rest_create_embargoed(api_client, user):
+    user.first_name = 'John'
+    user.last_name = 'Doe'
+    user.save()
+    api_client.force_authenticate(user=user)
+    name = 'Test Dandiset'
+    metadata = {'foo': 'bar'}
+
+    response = api_client.post(
+        '/api/dandisets/?embargo', {'name': name, 'metadata': metadata}, format='json'
+    )
+    assert response.data == {
+        'identifier': DANDISET_ID_RE,
+        'created': TIMESTAMP_RE,
+        'modified': TIMESTAMP_RE,
+        'contact_person': 'Doe, John',
+        'embargo_status': 'EMBARGOED',
+        'draft_version': {
+            'version': 'draft',
+            'name': name,
+            'asset_count': 0,
+            'size': 0,
+            'dandiset': {
+                'identifier': DANDISET_ID_RE,
+                'created': TIMESTAMP_RE,
+                'modified': TIMESTAMP_RE,
+                'contact_person': 'Doe, John',
+                'embargo_status': 'EMBARGOED',
+            },
+            'status': 'Pending',
+            'created': TIMESTAMP_RE,
+            'modified': TIMESTAMP_RE,
+        },
+        'most_recent_published_version': None,
+    }
+    id = int(response.data['identifier'])
+
+    # Creating a Dandiset has side affects.
+    # Verify that the user is the only owner.
+    dandiset = Dandiset.objects.get(id=id)
+    assert list(dandiset.owners.all()) == [user]
+
+    # Verify that a draft Version and VersionMetadata were also created.
+    assert dandiset.versions.count() == 1
+    assert dandiset.most_recent_published_version is None
+    assert dandiset.draft_version.version == 'draft'
+    assert dandiset.draft_version.name == name
+    assert dandiset.draft_version.status == Version.Status.PENDING
+
+    # Verify that computed metadata was injected
+    year = datetime.now().year
+    url = f'https://dandiarchive.org/dandiset/{dandiset.identifier}/draft'
+    assert dandiset.draft_version.metadata == {
+        **metadata,
+        'manifestLocation': [
+            f'https://api.dandiarchive.org/api/dandisets/{dandiset.identifier}/versions/draft/assets/'  # noqa: E501
+        ],
+        'name': name,
+        'identifier': DANDISET_SCHEMA_ID_RE,
+        'id': f'DANDI:{dandiset.identifier}/draft',
+        'version': 'draft',
+        'url': url,
+        'dateCreated': UTC_ISO_TIMESTAMP_RE,
+        'citation': (
+            f'{user.last_name}, {user.first_name} ({year}) {name} '
+            f'(Version draft) [Data set]. DANDI archive. {url}'
+        ),
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+        'schemaKey': 'Dandiset',
+        'access': [{'schemaKey': 'AccessRequirements', 'status': 'dandi:EmbargoedAccess'}],
+        'repository': 'https://dandiarchive.org/',
+        'contributor': [
+            {
+                'name': 'Doe, John',
+                'email': user.email,
+                'roleName': ['dcite:ContactPerson'],
+                'schemaKey': 'Person',
+                'affiliation': [],
+                'includeInCitation': True,
+            }
+        ],
+        'assetsSummary': {
+            'numberOfBytes': 0,
+            'numberOfFiles': 0,
+        },
+    }
+
+
+@pytest.mark.django_db
 def test_dandiset_rest_create_with_duplicate_identifier(api_client, admin_user, dandiset):
     api_client.force_authenticate(user=admin_user)
     name = 'Test Dandiset'

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -27,6 +27,7 @@ from dandiapi.api.models import Dandiset, Version
 from dandiapi.api.permissions import IsApprovedOrReadOnly
 from dandiapi.api.views.common import DANDISET_PK_PARAM, DandiPagination
 from dandiapi.api.views.serializers import (
+    CreateDandisetQueryParameterSerializer,
     DandisetDetailSerializer,
     UserSerializer,
     VersionMetadataSerializer,
@@ -138,15 +139,8 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         return super().get_object()
 
     @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
-                'embargo',
-                openapi.IN_QUERY,
-                type=openapi.TYPE_BOOLEAN,
-                description='If present, the dandiset will be embargoed.',
-            )
-        ],
         request_body=VersionMetadataSerializer(),
+        query_serializer=CreateDandisetQueryParameterSerializer(),
         responses={200: DandisetDetailSerializer()},
         operation_summary='Create a new dandiset.',
         operation_description='',
@@ -156,7 +150,9 @@ class DandisetViewSet(ReadOnlyModelViewSet):
         serializer = VersionMetadataSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        if request.query_params.get('embargo') is not None:
+        query_serializer = CreateDandisetQueryParameterSerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        if query_serializer.validated_data['embargo']:
             embargo_status = Dandiset.EmbargoStatus.EMBARGOED
         else:
             embargo_status = Dandiset.EmbargoStatus.OPEN

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -177,6 +177,7 @@ class DandisetViewSet(ReadOnlyModelViewSet):
                     'includeInCitation': True,
                 },
             ],
+            # TODO: move this into dandischema
             'access': [
                 {
                     'schemaKey': 'AccessRequirements',

--- a/dandiapi/api/views/dandiset.py
+++ b/dandiapi/api/views/dandiset.py
@@ -10,7 +10,6 @@ from django.db.utils import IntegrityError
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
-from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from guardian.decorators import permission_required_or_403
 from guardian.shortcuts import assign_perm, get_objects_for_user

--- a/dandiapi/api/views/serializers.py
+++ b/dandiapi/api/views/serializers.py
@@ -52,6 +52,10 @@ class DandisetSerializer(serializers.ModelSerializer):
         return extract_contact_person(latest_version)
 
 
+class CreateDandisetQueryParameterSerializer(serializers.Serializer):
+    embargo = serializers.BooleanField(required=False)
+
+
 class VersionMetadataSerializer(serializers.ModelSerializer):
     class Meta:
         model = Version


### PR DESCRIPTION
Resolves #645 

Add an `...?embargo=true` query parameter to the create dandiset endpoint. If present, the dandiset will be embargoed and the `access` metadata field set accordingly.