### PR TITLE
Fix zarr s3 upload

### DIFF
--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -73,6 +73,7 @@ class ZarrUploadFile(TimeStampedModel):
                     Params={
                         'Bucket': storage.bucket_name,
                         'Key': self.blob.name,
+                        'ACL': 'bucket-owner-full-control',
                     },
                     ExpiresIn=60,  # TODO proper expiration
                 )

--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -84,7 +84,11 @@ class ZarrUploadFile(TimeStampedModel):
             pass
         else:
             if isinstance(storage, MinioStorage):
-                return storage.client.presigned_put_object(
+                # storage.client will generate URLs like `http://minio:9000/...` when running in
+                # docker. To avoid this, use the secondary base_url_client which is configured to
+                # generate URLs like `http://localhost:9000/...`.
+                client = getattr(storage, 'base_url_client', storage.client)
+                return client.presigned_put_object(
                     bucket_name=storage.bucket_name,
                     object_name=self.blob.name,
                     expires=timedelta(seconds=60),  # TODO proper expiration

--- a/dandiapi/api/tests/test_zarr_upload.py
+++ b/dandiapi/api/tests/test_zarr_upload.py
@@ -202,7 +202,7 @@ def test_zarr_rest_upload_flow(authenticated_api_client, storage, zarr_archive: 
     )
     upload_url = resp.json()[0]['upload_url']
 
-    resp = requests.put(upload_url, data=text)
+    resp = requests.put(upload_url, data=text, headers={'X-Amz-ACL': 'bucket-owner-full-control'})
     assert resp.status_code == 200
 
     resp = authenticated_api_client.post(f'/api/zarr/{zarr_archive.zarr_id}/upload/complete/')


### PR DESCRIPTION
* Specify ACL=`bucket-owner-full-control`. I'm not sure why it is the way it is, but AWS requires that the client declare who will be the owner of the uploaded object. The staging (and also production) buckets have a rule that only requests with ACL=`bucket-owner-full-control` are permitted, which effectively makes it so that uploaded objects are always owned by the bucket owner. The downside of AWS doing it this way is that clients need to explicitly do this or their requests are not permitted, which is awful UX.

* Fix a bug where minio presigned zarr upload urls pointed to `http://minio:9000/...`, the name of the `minio` docker container. 