### PR TITLE
Don't leak spurious 400 error to client

### DIFF
--- a/dandiapi/api/tests/test_users.py
+++ b/dandiapi/api/tests/test_users.py
@@ -106,7 +106,7 @@ def test_user_search_blank_username(api_client, user):
             {'username': ''},
             format='json',
         ).data
-        == {'username': ['This field may not be blank.']}
+        == []
     )
 
 

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -6,7 +6,6 @@ from django.db.models import Q
 from django.http.response import HttpResponseBase
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view, parser_classes, permission_classes
-from rest_framework.exceptions import ValidationError
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request

--- a/dandiapi/api/views/users.py
+++ b/dandiapi/api/views/users.py
@@ -84,9 +84,7 @@ def users_search_view(request: Request) -> HttpResponseBase:
 
     # Swallow validation errors in the input string, and just send back null
     # results.
-    try:
-        request_serializer.is_valid(raise_exception=True)
-    except ValidationError as e:
+    if not request_serializer.is_valid(raise_exception=False):
         return Response([])
 
     username: str = request_serializer.validated_data['username']


### PR DESCRIPTION
When the input to user search doesn't validate, it leaks a 400 error through to the browser (specifically, in the user search form that appears in the "manage ownership" dialog) but doesn't break user functionality in any way. In fact, the user typing bad input into this field *shouldn't* be considered an error, and should instead just return no results.

Closes https://github.com/dandi/dandiarchive/issues/708.

Asking @dchiquito for a direct review, and @mvandenburgh to verify that this doesn't negatively impact frontend behavior.