### PR TITLE
Add zarr browse endpoint

### DIFF
--- a/dandiapi/api/views/__init__.py
+++ b/dandiapi/api/views/__init__.py
@@ -11,7 +11,7 @@ from .upload import (
 )
 from .users import users_me_view, users_search_view
 from .version import VersionViewSet
-from .zarr import ZarrViewSet
+from .zarr import ZarrViewSet, explore_zarr_archive
 
 __all__ = [
     'AssetViewSet',
@@ -23,6 +23,7 @@ __all__ = [
     'asset_metadata_view',
     'auth_token_view',
     'blob_read_view',
+    'explore_zarr_archive',
     'upload_initialize_view',
     'upload_complete_view',
     'upload_validate_view',

--- a/dandiapi/api/views/zarr.py
+++ b/dandiapi/api/views/zarr.py
@@ -201,7 +201,7 @@ def explore_zarr_archive(request, zarr_id: str, path: str):
     # Return a JSON blob which contains URLs to the contents of the directory.
     if path.endswith('/'):
         # Strip off the trailing /, it confuses the ZarrChecksumFileUpdater
-        path = path[:-1]
+        path = path.rstrip('/')
         # We use the .checksum file to determine the directory contents, since S3 cannot.
         listing = ZarrChecksumFileUpdater(
             zarr_archive=zarr_archive, zarr_directory_path=path

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -17,6 +17,7 @@ from dandiapi.api.views import (
     auth_token_view,
     authorize_view,
     blob_read_view,
+    explore_zarr_archive,
     info_view,
     stats_view,
     upload_complete_view,
@@ -103,6 +104,11 @@ urlpatterns = [
     path('api/users/search/', users_search_view),
     re_path(
         r'^api/users/questionnaire-form/$', user_questionnaire_form_view, name='user-questionnaire'
+    ),
+    re_path(
+        r'^api/zarr/(?P<zarr_id>[0-9a-f\-]{36})/explore/(?P<path>.*)?$',
+        explore_zarr_archive,
+        name='zarr-explore',
     ),
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),

--- a/dandiapi/urls.py
+++ b/dandiapi/urls.py
@@ -106,7 +106,7 @@ urlpatterns = [
         r'^api/users/questionnaire-form/$', user_questionnaire_form_view, name='user-questionnaire'
     ),
     re_path(
-        r'^api/zarr/(?P<zarr_id>[0-9a-f\-]{36})/explore/(?P<path>.*)?$',
+        r'^api/zarr/(?P<zarr_id>[0-9a-f\-]{36}).zarr/(?P<path>.*)?$',
         explore_zarr_archive,
         name='zarr-explore',
     ),


### PR DESCRIPTION
I've tested this code with the endpoint, it authenticates and can read a zarr file:
```
API_KEY = '...an API key...'
AUTH_HEADERS = {'Authorization': f'token {API_KEY}'}

zarr_archive = zarr.open(
    'http://localhost:8000/api/zarr/61b2ff83-314f-4f80-a92d-7b08885af059/explore/',
    storage_options={'headers': AUTH_HEADERS},
)
print(zarr_archive[:])
```

No tests yet for quick iteration