### PR TITLE
Hide embargoed versions assets

### DIFF
--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 from rest_framework.test import APIClient
 
-from dandiapi.api.models import Asset, AssetBlob, Version
+from dandiapi.api.models import Asset, AssetBlob, Dandiset, Version
 from dandiapi.api.views.serializers import AssetFolderSerializer, AssetSerializer
 
 from .fuzzy import HTTP_URL_RE, TIMESTAMP_RE, URN_RE, UTC_ISO_TIMESTAMP_RE, UUID_RE
@@ -913,3 +913,35 @@ def test_asset_direct_download_head(api_client, storage, version, asset):
 @pytest.mark.django_db
 def test_asset_direct_metadata(api_client, asset):
     assert json.loads(api_client.get(f'/api/assets/{asset.asset_id}/').content) == asset.metadata
+
+
+@pytest.mark.parametrize(
+    ('embargo_status'),
+    [
+        Dandiset.EmbargoStatus.EMBARGOED,
+        Dandiset.EmbargoStatus.UNEMBARGOING,
+    ],
+)
+@pytest.mark.django_db
+def test_asset_embargoed_visibility(
+    api_client, dandiset_factory, draft_version_factory, asset_factory, embargo_status
+):
+    dandiset = dandiset_factory(embargo_status=embargo_status)
+    version = draft_version_factory(dandiset=dandiset)
+    asset = asset_factory()
+    version.assets.add(asset)
+
+    # The version should be hidden because the dandiset it belongs to is embargoed
+    response = api_client.get(
+        f'/api/dandisets/{dandiset.identifier}/versions/{version.version}/assets/'
+    )
+    assert response.json() == {
+        'count': 0,
+        'next': None,
+        'previous': None,
+        'results': [],
+    }
+    response = api_client.get(
+        f'/api/dandisets/{dandiset.identifier}/versions/{version.version}/assets/{asset.asset_id}/'
+    )
+    assert response.status_code == 404

--- a/dandiapi/api/tests/test_version.py
+++ b/dandiapi/api/tests/test_version.py
@@ -7,6 +7,7 @@ import pytest
 
 from dandiapi.api import tasks
 from dandiapi.api.models import Asset, Version
+from dandiapi.api.models.dandiset import Dandiset
 
 from .fuzzy import TIMESTAMP_RE, URN_RE, UTC_ISO_TIMESTAMP_RE, VERSION_ID_RE
 
@@ -881,3 +882,29 @@ def test_version_rest_delete_draft_admin(api_client, admin_user, draft_version):
     assert response.status_code == 403
     assert response.data == 'Cannot delete draft versions'
     assert draft_version in Version.objects.all()
+
+
+@pytest.mark.parametrize(
+    ('embargo_status'),
+    [
+        Dandiset.EmbargoStatus.EMBARGOED,
+        Dandiset.EmbargoStatus.UNEMBARGOING,
+    ],
+)
+@pytest.mark.django_db
+def test_version_embargoed_visibility(
+    api_client, dandiset_factory, draft_version_factory, embargo_status
+):
+    dandiset = dandiset_factory(embargo_status=embargo_status)
+    version = draft_version_factory(dandiset=dandiset)
+
+    # The version should be hidden because the dandiset it belongs to is embargoed
+    response = api_client.get(f'/api/dandisets/{dandiset.identifier}/versions/')
+    assert response.json() == {
+        'count': 0,
+        'next': None,
+        'previous': None,
+        'results': [],
+    }
+    response = api_client.get(f'/api/dandisets/{dandiset.identifier}/versions/{version.version}/')
+    assert response.status_code == 404

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -164,8 +164,6 @@ class AssetFilter(filters.FilterSet):
 
 
 class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewSet):
-    queryset = Asset.objects.all().order_by('created')
-
     permission_classes = [IsApprovedOrReadOnly]
     serializer_class = AssetSerializer
     serializer_detail_class = AssetDetailSerializer
@@ -176,6 +174,13 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
 
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = AssetFilter
+
+    def get_queryset(self):
+        return (
+            Asset.objects.all()
+            .filter(versions__dandiset__in=Dandiset.objects.visible_to(self.request.user))
+            .order_by('created')
+        )
 
     @swagger_auto_schema(
         responses={

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -20,9 +20,6 @@ from dandiapi.api.views.serializers import (
 
 
 class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewSet):
-    queryset = Version.objects.all().select_related('dandiset').order_by('created')
-    queryset_detail = queryset
-
     permission_classes = [IsApprovedOrReadOnly]
     serializer_class = VersionSerializer
     serializer_detail_class = VersionDetailSerializer
@@ -30,6 +27,14 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
     lookup_field = 'version'
     lookup_value_regex = Version.VERSION_REGEX
+
+    def get_queryset(self):
+        return (
+            Version.objects.all()
+            .select_related('dandiset')
+            .filter(dandiset__in=Dandiset.objects.visible_to(self.request.user))
+            .order_by('created')
+        )
 
     @swagger_auto_schema(
         responses={


### PR DESCRIPTION
I missed a spot when concealing the `DandisetViewSet` from returning data on embargoed Dandisets: Versions and Assets would still dispense data happily even when associated with embargoed Dandisets. This fixes that, and adds tests.

Technically, this implementation leaks the fact that an embargoed dandiset exists with that identifier, since querying `/api/dandisets/{embargoed_dandiset_id}/versions/` will return an empty pagination instead of a 404. I think that's fine, since embargoed dandisets will conspicuously occupy gaps in the dandiset identifier sequence, and there isn't anything a bad actor can do with an identifier. @waxlamp can you advise?

Fixes #667 