### PR TITLE
Remove `AssetInline` to improve performance

### DIFF
--- a/dandiapi/api/admin.py
+++ b/dandiapi/api/admin.py
@@ -41,10 +41,6 @@ class DandisetAdmin(GuardedModelAdmin):
     inlines = [VersionInline]
 
 
-class AssetInline(LimitedTabularInline):
-    model = Asset.versions.through
-
-
 @admin.register(Version)
 class VersionAdmin(admin.ModelAdmin):
     list_display = [
@@ -57,7 +53,6 @@ class VersionAdmin(admin.ModelAdmin):
         'created',
     ]
     list_display_links = ['id', 'version']
-    inlines = [AssetInline]
 
     def get_queryset(self, request: HttpRequest) -> QuerySet:
         # Using the `asset_count` property here results in N queries being made


### PR DESCRIPTION
Currently, `Version` detail admin pages such as https://api.dandiarchive.org/admin/api/version/636/change/ fail to load because they are querying the entire `Asset.versions` through table for every asset in order to display them in an inline. 

The asset inline's use is limited by the fact that it only shows a small subset of assets, so I just removed it.

Fixes #539.