### PR TITLE
Fix zarr metadata

### DIFF
--- a/dandiapi/api/manifests.py
+++ b/dandiapi/api/manifests.py
@@ -40,6 +40,7 @@ def s3_url(path: str):
     """Turn an object path into a fully qualified S3 URL."""
     storage = create_s3_storage(settings.DANDI_DANDISETS_BUCKET_NAME)
     signed_url = storage.url(path)
+    # Strip off the query parameters from the presigning, as they are different every time
     parsed = urlparse(signed_url)
     s3_url = urlunparse((parsed[0], parsed[1], parsed[2], '', '', ''))
     return s3_url

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -56,6 +56,7 @@ class BaseAssetBlob(TimeStampedModel):
     @property
     def s3_url(self) -> str:
         signed_url = self.blob.url
+        # Strip off the query parameters from the presigning, as they are different every time
         parsed = urlparse(signed_url)
         s3_url = urlunparse((parsed[0], parsed[1], parsed[2], '', '', ''))
         return s3_url

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -192,6 +192,8 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
                 'https://raw.githubusercontent.com/dandi/schema/master/releases/'
                 f'{schema_version}/context.json'
             )
+        if self.is_zarr:
+            metadata['encodingFormat'] = 'application/x-zarr'
         return metadata
 
     def published_metadata(self):

--- a/dandiapi/api/models/asset.py
+++ b/dandiapi/api/models/asset.py
@@ -175,7 +175,7 @@ class Asset(PublishableMetadataMixin, TimeStampedModel):
         if self.is_blob:
             s3_url = self.blob.s3_url
         else:
-            s3_url = self.zarr.s3_path('')
+            s3_url = self.zarr.s3_url
 
         metadata = {
             **self.metadata,

--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from pathlib import Path
+from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 
 from django.conf import settings
@@ -168,6 +169,13 @@ class ZarrArchive(TimeStampedModel):
     def s3_path(self, zarr_path: str | Path):
         """Generate a full S3 object path from a path in this zarr_archive."""
         return f'{settings.DANDI_DANDISETS_BUCKET_PREFIX}{settings.DANDI_ZARR_PREFIX_NAME}/{self.zarr_id}/{str(zarr_path)}'  # noqa: E501
+
+    @property
+    def s3_url(self):
+        signed_url = ZarrUploadFile.blob.field.storage.url(self.s3_path(''))
+        parsed = urlparse(signed_url)
+        s3_url = urlunparse((parsed[0], parsed[1], parsed[2], '', '', ''))
+        return s3_url
 
     def get_checksum(self, path: str | Path = ''):
         listing = ZarrChecksumFileUpdater(self, path).read_checksum_file()

--- a/dandiapi/api/models/zarr.py
+++ b/dandiapi/api/models/zarr.py
@@ -173,6 +173,7 @@ class ZarrArchive(TimeStampedModel):
     @property
     def s3_url(self):
         signed_url = ZarrUploadFile.blob.field.storage.url(self.s3_path(''))
+        # Strip off the query parameters from the presigning, as they are different every time
         parsed = urlparse(signed_url)
         s3_url = urlunparse((parsed[0], parsed[1], parsed[2], '', '', ''))
         return s3_url

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -267,7 +267,7 @@ def test_asset_populate_metadata_zarr(draft_asset_factory, zarr_archive):
         'asset-direct-download',
         kwargs={'asset_id': str(asset.asset_id)},
     )
-    s3_url = f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/test-zarr/{zarr_archive.zarr_id}/'  # noqa: E501
+    s3_url = f'http://{settings.MINIO_STORAGE_ENDPOINT}/test-dandiapi-dandisets/test-prefix/test-zarr/{zarr_archive.zarr_id}/'  # noqa: E501
     assert asset.metadata == {
         **raw_metadata,
         'id': f'dandiasset:{asset.asset_id}',

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -267,13 +267,13 @@ def test_asset_populate_metadata_zarr(draft_asset_factory, zarr_archive):
         'asset-direct-download',
         kwargs={'asset_id': str(asset.asset_id)},
     )
-    blob_url = asset.zarr.s3_path('')
+    s3_url = f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/test-zarr/{zarr_archive.zarr_id}/'  # noqa: E501
     assert asset.metadata == {
         **raw_metadata,
         'id': f'dandiasset:{asset.asset_id}',
         'path': asset.path,
         'identifier': str(asset.asset_id),
-        'contentUrl': [download_url, blob_url],
+        'contentUrl': [download_url, s3_url],
         'contentSize': asset.size,
         'digest': asset.digest,
         # This should be injected on all zarr assets

--- a/dandiapi/api/tests/test_asset.py
+++ b/dandiapi/api/tests/test_asset.py
@@ -253,6 +253,35 @@ def test_asset_populate_metadata(draft_asset_factory):
     }
 
 
+@pytest.mark.django_db
+def test_asset_populate_metadata_zarr(draft_asset_factory, zarr_archive):
+    raw_metadata = {
+        'foo': 'bar',
+        'schemaVersion': settings.DANDI_SCHEMA_VERSION,
+    }
+
+    # This should trigger _populate_metadata to inject all the computed metadata fields
+    asset = draft_asset_factory(metadata=raw_metadata, blob=None, zarr=zarr_archive)
+
+    download_url = 'https://api.dandiarchive.org' + reverse(
+        'asset-direct-download',
+        kwargs={'asset_id': str(asset.asset_id)},
+    )
+    blob_url = asset.zarr.s3_path('')
+    assert asset.metadata == {
+        **raw_metadata,
+        'id': f'dandiasset:{asset.asset_id}',
+        'path': asset.path,
+        'identifier': str(asset.asset_id),
+        'contentUrl': [download_url, blob_url],
+        'contentSize': asset.size,
+        'digest': asset.digest,
+        # This should be injected on all zarr assets
+        'encodingFormat': 'application/x-zarr',
+        '@context': f'https://raw.githubusercontent.com/dandi/schema/master/releases/{settings.DANDI_SCHEMA_VERSION}/context.json',  # noqa: E501
+    }
+
+
 # API Tests
 
 
@@ -422,7 +451,7 @@ def test_asset_create_zarr(api_client, user, draft_version, zarr_archive):
     path = 'test/create/asset.txt'
     metadata = {
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
-        'encodingFormat': 'application/x-nwb',
+        'encodingFormat': 'application/x-zarr',
         'path': path,
         'meta': 'data',
         'foo': ['bar', 'baz'],
@@ -467,7 +496,7 @@ def test_asset_create_no_blob_or_zarr(api_client, user, draft_version):
     path = 'test/create/asset.txt'
     metadata = {
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
-        'encodingFormat': 'application/x-nwb',
+        'encodingFormat': 'application/x-zarr',
         'path': path,
         'meta': 'data',
         'foo': ['bar', 'baz'],
@@ -492,7 +521,7 @@ def test_asset_create_blob_and_zarr(api_client, user, draft_version, asset_blob,
     path = 'test/create/asset.txt'
     metadata = {
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
-        'encodingFormat': 'application/x-nwb',
+        'encodingFormat': 'application/x-zarr',
         'path': path,
         'meta': 'data',
         'foo': ['bar', 'baz'],
@@ -667,7 +696,7 @@ def test_asset_rest_update_zarr(api_client, user, draft_version, asset, zarr_arc
     new_path = 'test/asset/rest/update.txt'
     new_metadata = {
         'schemaVersion': settings.DANDI_SCHEMA_VERSION,
-        'encodingFormat': 'application/x-nwb',
+        'encodingFormat': 'application/x-zarr',
         'path': new_path,
         'foo': 'bar',
         'num': 123,

--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -48,6 +48,11 @@ from dandiapi.api.views.serializers import (
 
 
 def _download_asset(asset: Asset):
+    if asset.is_zarr:
+        return HttpResponseRedirect(
+            reverse('zarr-explore', kwargs={'zarr_id': asset.zarr.zarr_id, 'path': ''})
+        )
+
     storage = asset.blob.blob.storage
 
     if isinstance(storage, S3Boto3Storage):


### PR DESCRIPTION
* Fixes #676 
* Fixes #677 
* Include a full S3 URL as the second `contentUrl` metadata field for zarr archives.

Triggered by discussion on https://github.com/dandi/dandi-cli/issues/852#issuecomment-1007758461