### PR TITLE
Correctly invoke super().get_queryset()

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -164,6 +164,8 @@ class AssetFilter(filters.FilterSet):
 
 
 class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewSet):
+    queryset = Asset.objects.all().order_by('created')
+
     permission_classes = [IsApprovedOrReadOnly]
     serializer_class = AssetSerializer
     serializer_detail_class = AssetDetailSerializer
@@ -177,9 +179,9 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
 
     def get_queryset(self):
         return (
-            Asset.objects.all()
+            super()
+            .get_queryset()
             .filter(versions__dandiset__in=Dandiset.objects.visible_to(self.request.user))
-            .order_by('created')
         )
 
     @swagger_auto_schema(

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -20,6 +20,8 @@ from dandiapi.api.views.serializers import (
 
 
 class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewSet):
+    queryset = Version.objects.all().select_related('dandiset').order_by('created')
+
     permission_classes = [IsApprovedOrReadOnly]
     serializer_class = VersionSerializer
     serializer_detail_class = VersionDetailSerializer
@@ -30,10 +32,9 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
 
     def get_queryset(self):
         return (
-            Version.objects.all()
-            .select_related('dandiset')
+            super()
+            .get_queryset()
             .filter(dandiset__in=Dandiset.objects.visible_to(self.request.user))
-            .order_by('created')
         )
 
     @swagger_auto_schema(


### PR DESCRIPTION
Turns out `NestedViewSetMixin` already implemented `get_queryset`, so when I overwrote it I also overwrote the code that filters versions/assets. This restores it.