### PR TITLE
Fix GH Actions config files

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,11 +1,13 @@
 name: CI for backend
 on:
   pull_request:
-    paths-ignore: "web/**"
+    paths-ignore:
+      - "web/**"
   push:
     branches:
       - master
-    paths-ignore: "web/**"
+    paths-ignore:
+      - "web/**"
   schedule:
     - cron: "0 0 * * *"
 jobs:

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
-    paths-ignore: "web/**"
+    paths-ignore:
+      - "web/**"
   pull_request:
-    paths-ignore: "web/**"
+    paths-ignore:
+      - "web/**"
 
 jobs:
   build-image:

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,6 +4,8 @@ on:
   release:
     types:
       - published # use `published` instead of `created` b/c `created` also runs on draft releases
+    paths-ignore:
+      - "web/**"
 
 jobs:
   deploy:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - "web/**"
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixes some lingering GH Actions issues that were revealed after merging #675.

- Don't run Heroku deployment actions for frontend-only changes
- Fix `paths-ignore` formatting in some workflow files