### PR TITLE
Make ViewSet querysets distinct

### DIFF
--- a/dandiapi/api/views/asset.py
+++ b/dandiapi/api/views/asset.py
@@ -199,6 +199,7 @@ class AssetViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelViewS
             super()
             .get_queryset()
             .filter(versions__dandiset__in=Dandiset.objects.visible_to(self.request.user))
+            .distinct()
         )
 
     @swagger_auto_schema(

--- a/dandiapi/api/views/version.py
+++ b/dandiapi/api/views/version.py
@@ -35,6 +35,7 @@ class VersionViewSet(NestedViewSetMixin, DetailSerializerMixin, ReadOnlyModelVie
             super()
             .get_queryset()
             .filter(dandiset__in=Dandiset.objects.visible_to(self.request.user))
+            .distinct()
         )
 
     @swagger_auto_schema(


### PR DESCRIPTION
The query to filter versions/assets against visible Dandisets involves a
JOIN, which causes duplicate assets to be included in the queryset when
the same asset belongs to multiple versions in the same Dandiset.

The solution is to make the queryset distinct.

Fixes #686 