### PR TITLE
Fix zarr directories not having / suffix

### DIFF
--- a/dandiapi/api/tests/conftest.py
+++ b/dandiapi/api/tests/conftest.py
@@ -119,6 +119,7 @@ def minio_storage_factory() -> MinioStorage:
         base_url=(
             f'{"https" if settings.MINIO_STORAGE_USE_HTTPS else "http"}:'
             f'//{settings.MINIO_STORAGE_ENDPOINT}'
+            f'/{settings.DANDI_DANDISETS_BUCKET_NAME}'
         ),
     )
 

--- a/dandiapi/api/tests/test_zarr.py
+++ b/dandiapi/api/tests/test_zarr.py
@@ -2,7 +2,7 @@ import pytest
 
 from dandiapi.api.models import ZarrArchive, ZarrUploadFile
 from dandiapi.api.tests.fuzzy import UUID_RE
-from dandiapi.api.zarr_checksums import EMPTY_CHECKSUM
+from dandiapi.api.zarr_checksums import EMPTY_CHECKSUM, ZarrChecksumUpdater
 
 
 @pytest.mark.django_db
@@ -152,3 +152,69 @@ def test_zarr_rest_delete_upload_in_progress(
     )
     assert resp.status_code == 400
     assert resp.json() == ['Cannot delete files while an upload is in progress.']
+
+
+@pytest.mark.parametrize(
+    ('path', 'status', 'directories', 'files'),
+    [
+        ('', 200, ['foo/'], []),
+        ('foo/', 200, ['foo/bar/'], ['foo/a', 'foo/b']),
+        ('foo/bar/', 200, [], ['foo/bar/c']),
+        ('foo', 302, None, None),
+        ('foo/a', 302, None, None),
+        ('foo/b', 302, None, None),
+        ('foo/bar/c', 302, None, None),
+        ('gibberish', 302, None, None),
+    ],
+    ids=[
+        'root-dir',
+        'foo/-dir',
+        'foo/bar/-dir',
+        'foo-file',
+        'foo/a-file',
+        'foo/b-file',
+        'foo/bar/c-file',
+        'gibberish-file',
+    ],
+)
+@pytest.mark.django_db
+def test_zarr_explore(
+    api_client,
+    storage,
+    zarr_archive: ZarrArchive,
+    zarr_upload_file_factory,
+    path,
+    status,
+    directories,
+    files,
+):
+    # Pretend like ZarrUploadFile was defined with the given storage
+    ZarrUploadFile.blob.field.storage = storage
+    a: ZarrUploadFile = zarr_upload_file_factory(zarr_archive=zarr_archive, path='foo/a')
+    b: ZarrUploadFile = zarr_upload_file_factory(zarr_archive=zarr_archive, path='foo/b')
+    c: ZarrUploadFile = zarr_upload_file_factory(zarr_archive=zarr_archive, path='foo/bar/c')
+
+    # Write the checksum files
+    ZarrChecksumUpdater(zarr_archive).update_file_checksums(
+        [a.to_checksum(), b.to_checksum(), c.to_checksum()],
+    )
+
+    resp = api_client.get(
+        f'/api/zarr/{zarr_archive.zarr_id}.zarr/{path}',
+    )
+    assert resp.status_code == status
+    if status == 200:
+        assert resp.json() == {
+            'directories': [
+                f'http://localhost:8000/api/zarr/{zarr_archive.zarr_id}.zarr/{dirpath}'
+                for dirpath in directories
+            ],
+            'files': [
+                f'http://localhost:8000/api/zarr/{zarr_archive.zarr_id}.zarr/{filepath}'
+                for filepath in files
+            ],
+        }
+    if status == 302:
+        assert resp.headers['Location'].startswith(
+            f'http://localhost:9000/test-dandiapi-dandisets/test-prefix/test-zarr/{zarr_archive.zarr_id}/{path}?'
+        )

--- a/dandiapi/api/views/zarr.py
+++ b/dandiapi/api/views/zarr.py
@@ -209,7 +209,7 @@ def explore_zarr_archive(request, zarr_id: str, path: str):
         if listing is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         directories = [
-            settings.DANDI_API_URL + reverse('zarr-explore', args=[zarr_id, directory.path])
+            settings.DANDI_API_URL + reverse('zarr-explore', args=[zarr_id, directory.path]) + '/'
             for directory in listing.checksums.directories
         ]
         files = [


### PR DESCRIPTION
Fixes #693 

Also add a test for the endpoint since we didn't have one yet.

https://github.com/dandi/dandi-api/commit/ae63ff5664686a30b2249cd33cc62f2a78670fe3 also fixes a minor bug with our testing configuration:
>django-minio-storage removes the bucket name from the presigned URL, as
it assumes that the `base_url` for the `MinioStorage` object already
includes the bucket name. We were not including that in the `base_url`,
so we should.
>
>See
https://github.com/py-pa/django-minio-storage/blob/8ce77cd8eae0d86fa3200e74cde64144c0338f37/minio_storage/storage.py#L279-L282